### PR TITLE
Require Capture::Tiny >= 0.12

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -8,7 +8,7 @@ Module::Build->new(
     requires           => { perl            => '5.10.1' },
     configure_requires => { 'Module::Build' => '0.35'  },
     build_requires     => {
-        'Capture::Tiny'        => 0,
+        'Capture::Tiny'        => '0.12',
         'Module::Build'        => '0.35',
         'Test::MockModule'     => '0.05',
         'Test::More'           => '0.17',


### PR DESCRIPTION
Hi David,

capture_stderr() is used in the test suite, but Capture::Tiny < 0.12 doesn't have that function, so I think it's a good idea to make 0.12 an explicit requirement.

What do you think?
