### PR TITLE
Remove test dependency on local config.

### DIFF
--- a/lib/App/Sqitch/Config.pm
+++ b/lib/App/Sqitch/Config.pm
@@ -21,7 +21,7 @@ my $SYSTEM_DIR = undef;
 
 sub user_dir {
     require File::HomeDir;
-    my $hd = File::HomeDir->my_home or hurl config => __(
+    my $hd = $ENV{SQITCH_USER_DIR} || File::HomeDir->my_home or hurl config => __(
         "Could not determine home directory"
     );
     return dir $hd, '.sqitch';

--- a/t/add.t
+++ b/t/add.t
@@ -19,9 +19,13 @@ use MockOutput;
 
 my $CLASS = 'App::Sqitch::Command::add';
 
+$ENV{SQITCH_USER_DIR} = '.';
+
 ok my $sqitch = App::Sqitch->new(
     top_dir => Path::Class::Dir->new('sql'),
 ), 'Load a sqitch sqitch object';
+
+
 my $config = $sqitch->config;
 
 sub dep($$) {

--- a/t/revert.t
+++ b/t/revert.t
@@ -14,6 +14,10 @@ use MockOutput;
 my $CLASS = 'App::Sqitch::Command::revert';
 require_ok $CLASS or die;
 
+$ENV{SQITCH_CONFIG} = 'nonexistent.conf';
+$ENV{SQITCH_USER_CONFIG} = 'nonexistent.user';
+$ENV{SQITCH_SYSTEM_CONFIG} = 'nonexistent.sys';
+
 isa_ok $CLASS, 'App::Sqitch::Command';
 can_ok $CLASS, qw(
     options


### PR DESCRIPTION
The tests depend on both:
- the systems locale
- the user sqitch configuration (and maybe the system configuration too)

For example, the add.t test will incorrectly use the users "templates" directory (~/.sqitch/templates), or the revert.t test will assume that no deploy variables are set.

This patch fixes the dependency to the sqitch configuration, by:
- providing "dummy" user and system configuration for the revert test
- looking up the user directory in an environment variable before assuming the ~/.sqitch/ directory.

However, the dependency on the systems locale is not fixed. Would it be possible to set the LANG to en_US before each test ?
