### PR TITLE
Fix "Cannot find deploy template" errors when installed into a local::lib

### DIFF
--- a/inc/Module/Build/Sqitch.pm
+++ b/inc/Module/Build/Sqitch.pm
@@ -161,7 +161,7 @@ sub process_pm_files {
 
     $self->do_system(
         $self->perl, '-i.bak', '-pe',
-        qq{s{my \\\$SYSTEM_DIR = undef}{my \\\$SYSTEM_DIR = q{$etc}}},
+        qq{s{my \\\$SYSTEM_DIR = undef}{my \\\$SYSTEM_DIR = q{\Q$etc\E}}},
         $pm,
     );
     unlink "$pm.bak";


### PR DESCRIPTION
The lib paths for local::lib contain an "@", which was unwittingly
interpolated in the spawned perl process which rewrites
App::Sqitch::Config.  This caused broken paths to sqitch's etc dir.

Protect against secondary interpolation by escaping special characters.
