### PR TITLE
Update sqitchtutorial-oracle.pod

### DIFF
--- a/lib/sqitchtutorial-oracle.pod
+++ b/lib/sqitchtutorial-oracle.pod
@@ -455,7 +455,7 @@ changes are verified after deploying them:
   > sqitch config --bool rebase.verify true
 
 We'll see the L<C<rebase>|sqitch-rebase> command a bit later. In the meantime,
-let's commit the new configuration and and make some more changes!
+let's commit the new configuration and make some more changes!
 
   > git commit -am 'Set default target and always verify.'
   [master c4a308a] Set default target and always verify.
@@ -491,7 +491,7 @@ this:
 
 A few things to notice here. On the second line, the dependence on the
 C<appschema> change has been listed in a comment. This doesn't do anything,
-but the default SQLite C<deploy> template lists it here for your reference
+but the default Oracle C<deploy> template lists it here for your reference
 while editing the file. Useful, right?
 
 The table itself will been created in the C<flipr> schema. This is why we need
@@ -514,9 +514,6 @@ from the table with a false C<WHERE> clause. Add this to F<verify/users.sql>:
   SELECT nickname, password, timestamp
     FROM flipr.users
    WHERE 1 = 1;
-
-Note that we have once again set the SQL*Plus error handling. In truth, this
-line should be in I<all> Sqitch scripts.
 
 Now for the revert script: all we have to do is drop the table. Add this to
 F<revert/users.sql>:


### PR DESCRIPTION
A couple of small typo fixes.

I'm unsure about the deletion around line 518.  You say above that `squitch` automatically inserts the error handling code, and you have *not* included it in the example, so I think that the prose suggesting that you did (and one should) is a left-over.