### PR TITLE
Add missing ')' in command output.

### DIFF
--- a/lib/App/Sqitch/Engine.pm
+++ b/lib/App/Sqitch/Engine.pm
@@ -167,7 +167,7 @@ sub deploy {
         # Just return if there is nothing to do.
         if ($to_index == $plan->position) {
             $sqitch->info(__x(
-                'Nothing to deploy (already at "{change}"',
+                'Nothing to deploy (already at "{change}")',
                 change => $to
             ));
             return $self;


### PR DESCRIPTION
The output from this command:

```
georgewh-L0DKQ1:flipr georgewh$ sqitch deploy appschema
Nothing to deploy (already at "appschema"
```

appears to be missing a ')'.