### PR TITLE
Add a documentation note about the MySQL::Config requirement to read my.cnf files

### DIFF
--- a/lib/sqitch-passwords.pod
+++ b/lib/sqitch-passwords.pod
@@ -103,7 +103,7 @@ For MySQL, passwords can be specified in the
 L<F</etc/my.cnf> and F<~/.my.cnf> files|http://dev.mysql.com/doc/refman/5.1/en/password-security-user.html#idm139947650158560>.
 These files must limit access only to the current user (C<0600>) and. Sqitch
 will look for a password under the C<[client]> and C<[mysql]> sections, in that
-order.
+order. This requires L<MySQL::Config> to be installed in order to work.
 
 =item Oracle
 


### PR DESCRIPTION
I had trouble figuring out why my system wasn't reading my.cnf files as documented. Reading the code, I realized I was missing an optional dependency. Added a doc to help others with this problem in the future.