### PR TITLE
s/-engine/--engine/

### DIFF
--- a/lib/sqitchtutorial-mysql.pod
+++ b/lib/sqitchtutorial-mysql.pod
@@ -52,7 +52,7 @@ project must have a name associated with it, and, optionally, a unique URI. We
 recommend including the URI, as it increases the uniqueness of object
 identifiers internally, so let's specify one when we initialize Sqitch:
 
-  > sqitch init flipr --uri https://github.com/theory/sqitch-mysql-intro/ -engine mysql
+  > sqitch init flipr --uri https://github.com/theory/sqitch-mysql-intro/ --engine mysql
   Created sqitch.conf
   Created sqitch.plan
   Created deploy/
@@ -72,7 +72,7 @@ Let's have a look at F<sqitch.conf>:
   	# client = /usr/local/mysql/bin/mysql
 
 Good, it picked up on the fact that we're creating changes for the MySQL
-engine, thanks to the C<-engine mysql> option, and saved it to the file.
+engine, thanks to the C<--engine mysql> option, and saved it to the file.
 Furthermore, it wrote a commented-out C<[engine "mysql"]> section with all the
 available MySQL engine-specific settings commented out and ready to be edited
 as appropriate.


### PR DESCRIPTION
```
bash-3.2$ sqitch init flipr --uri https://github.com/theory/sqitch-mysql-intro/ -engine mysql
Unknown option: e
Unknown option: n
Unknown option: g
Unknown option: i
Unknown option: n
Unknown option: e
Usage:
      sqitch init <project>
      sqitch init <project> --uri <uri>

Options:
        --uri        <uri>          associate a URI with the project plan
        --engine     <engine>       database engine
        --top-dir    <dir>          path to directory with plan and scripts
        --plan-file  <file>         path to deployment plan file
        --target     <target>       database target
        --registry   <registry>     registry schema or database
        --client     <path>         path to engine command-line client
        --extension  <ext>          change script file name extension
        --dir        <name>=<path>  path to named directory

                             --   --  (master)     
bash-3.2$ sqitch init flipr --uri https://github.com/theory/sqitch-mysql-intro/ --engine mysql
Created sqitch.conf
Created sqitch.plan
Created deploy/
Created revert/
Created verify/
```