### PR TITLE
Fix error when running `sqitch engine add pg something`

### DIFF
--- a/lib/App/Sqitch/Command/engine.pm
+++ b/lib/App/Sqitch/Command/engine.pm
@@ -72,6 +72,7 @@ sub list {
 sub _target {
     my ($self, $engine, $name) = @_;
     my $target = $self->properties->{target} || $name || return;
+    my $config = $self->sqitch->config;
 
     if ($target =~ /:/) {
         # It's  URI. Return it if it uses the proper engine.
@@ -85,7 +86,7 @@ sub _target {
     }
 
     # Otherwise, it needs to be a known target from the config.
-    return $target if $self->config->get(key => "target.$target.uri");
+    return $target if $config->get(key => "target.$target.uri");
     hurl engine => __x(
         'Unknown target "{target}"',
         target => $target


### PR DESCRIPTION
Hi there!

sqitch seems great. I'm trying to get the hang of it to use it with posgrest.
I was going through the tutorial when I ran into the following error:
```
> sqitch engine add pg flipr_test
Can't locate object method "config" via package "App::Sqitch::Command::engine" at /usr/local/lib/perl5/App/Sqitch/Command/engine.pm line 88.
```

This fix made the command update my sqitch.conf properly.

Let me know if you'd like me to tweak something about the fix. I hope this helps! :-)
