### PR TITLE
Oracle Wallet Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 .build/
 *.mo
 .al
+*.komodoproject

--- a/lib/App/Sqitch/Engine/oracle.pm
+++ b/lib/App/Sqitch/Engine/oracle.pm
@@ -617,6 +617,8 @@ sub log_revert_change {
         ora_type => DBD::Oracle::ORA_VARCHAR2()
     });
     $sth->execute;
+    
+    my $aggcol = sprintf $self->_listagg_format, 'dependency';
 
     # Retrieve dependencies.
     my $depcol = sprintf $self->_listagg_format, 'dependency';

--- a/lib/App/Sqitch/Engine/oracle.pm
+++ b/lib/App/Sqitch/Engine/oracle.pm
@@ -708,16 +708,16 @@ sub _run {
 sub _capture {
     my $self = shift;
     my $conn = $self->_script(@_);
-    my (@out, @err);
+    my @out;
 
     require IPC::Run3;
     IPC::Run3::run3(
-        [$self->sqlplus], \$conn, \@out, \@err,
+        [$self->sqlplus], \$conn, \@out, undef,
         { return_if_system_error => 1 },
     );
-    if (my $err = $? or @err) { 
+    if (my $err = $?) {
         # Ugh, send everything to STDERR.
-        $self->sqitch->vent(@out, @err);
+        $self->sqitch->vent(@out);
         hurl io => __x(
             '{command} unexpectedly returned exit value {exitval}',
             command => $self->client,

--- a/lib/App/Sqitch/Engine/oracle.pm
+++ b/lib/App/Sqitch/Engine/oracle.pm
@@ -617,8 +617,6 @@ sub log_revert_change {
         ora_type => DBD::Oracle::ORA_VARCHAR2()
     });
     $sth->execute;
-    
-    my $aggcol = sprintf $self->_listagg_format, 'dependency';
 
     # Retrieve dependencies.
     my $depcol = sprintf $self->_listagg_format, 'dependency';


### PR DESCRIPTION
In shifting to use Oracle wallets for improved security, we found that sqitch almost but not quite supports connectivity strings needed for wallets.