### PR TITLE
documentation fix

### DIFF
--- a/lib/sqitchtutorial-mysql.pod
+++ b/lib/sqitchtutorial-mysql.pod
@@ -34,7 +34,7 @@ Usually the first thing to do when starting a new project is to create a
 source code repository. So let's do that with Git:
 
   > mkdir flipr
-  > cd flipr 
+  > cd flipr
   > git init .
   Initialized empty Git repository in /flipr/.git/
   > touch README.md
@@ -279,13 +279,13 @@ from the registry database:
   # Name:     appuser
   # Deployed: 2013-12-31 13:13:17 -0800
   # By:       Marge N. O’Vera <marge@example.com>
-  # 
+  #
   Nothing to deploy (up-to-date)
 
 Let's make sure that we can revert the change:
 
   > sqitch revert db:mysql://root@/flipr_test
-  Revert all changes from db:mysql://root@/flipr_test? [Yes] 
+  Revert all changes from db:mysql://root@/flipr_test? [Yes]
     - appuser .. ok
 
 The L<C<revert>|sqitch-revert> command first prompts to make sure that we
@@ -366,7 +366,7 @@ When we look at the status, the deployment will be there:
   # Name:     appuser
   # Deployed: 2013-12-31 13:28:23 -0800
   # By:       Marge N. O’Vera <marge@example.com>
-  # 
+  #
   Nothing to deploy (up-to-date)
 
 =head1 On Target
@@ -399,7 +399,7 @@ simpler from here on in, e.g.:
   # Name:     appuser
   # Deployed: 2013-12-31 13:28:23 -0800
   # By:       Marge N. O’Vera <marge@example.com>
-  # 
+  #
   Nothing to deploy (up-to-date)
 
 Yay, that allows things to be a little more concise. Let's also make sure that
@@ -505,7 +505,7 @@ Now have a look at the status:
   # Name:     users
   # Deployed: 2013-12-31 13:34:25 -0800
   # By:       Marge N. O’Vera <marge@example.com>
-  # 
+  #
   Nothing to deploy (up-to-date)
 
 Success! Let's make sure we can revert the change, as well:
@@ -544,7 +544,7 @@ undeployed changes:
   # Name:     appuser
   # Deployed: 2013-12-31 13:28:23 -0800
   # By:       Marge N. O’Vera <marge@example.com>
-  # 
+  #
   Undeployed change:
     * users
 
@@ -583,7 +583,7 @@ Looks good. Check the status:
   # Name:     users
   # Deployed: 2013-12-31 13:37:02 -0800
   # By:       Marge N. O’Vera <marge@example.com>
-  # 
+  #
   Nothing to deploy (up-to-date)
 
 Excellent. Let's do some more!
@@ -718,7 +718,7 @@ something like:
   -- Revert flipr:change_pass from mysql
   BEGIN;
   DROP FUNCTION change_pass;
-  REVERT;
+  COMMIT;
 
 Try em out!
 
@@ -747,7 +747,7 @@ And what's the status?
   # Name:     change_pass
   # Deployed: 2013-12-31 13:39:49 -0800
   # By:       Marge N. O’Vera <marge@example.com>
-  # 
+  #
   Nothing to deploy (up-to-date)
 
 Looks good. Let's make sure revert works:
@@ -784,7 +784,7 @@ the last deployed change. Looks good. Let's do the commit and re-deploy dance:
   # Name:     change_pass
   # Deployed: 2013-12-31 13:40:40 -0800
   # By:       Marge N. O’Vera <marge@example.com>
-  # 
+  #
   Nothing to deploy (up-to-date)
 
   > sqitch verify
@@ -859,7 +859,7 @@ C<@v1.0.0-dev1>. Let's have a look at the status:
   # Tag:      @v1.0.0-dev1
   # Deployed: 2013-12-31 13:44:04 -0800
   # By:       Marge N. O’Vera <marge@example.com>
-  # 
+  #
   Nothing to deploy (up-to-date)
 
 Looks good, eh? Go ahead and revert it:
@@ -953,10 +953,10 @@ Look good?
   # Name:     flips
   # Deployed: 2013-12-31 13:55:04 -0800
   # By:       Marge N. O’Vera <marge@example.com>
-  # 
+  #
   # Tag:
   #   @v1.0.0-dev1 - 2013-12-31 13:55:04 -0800 - Marge N. O’Vera <marge@example.com>
-  # 
+  #
   Nothing to deploy (up-to-date)
 
 Note the use of C<--show tags> to show all the deployed tags. Now make it so:
@@ -1083,10 +1083,10 @@ should end up looking something like this:
   # Name:     delete_flip
   # Deployed: 2013-12-31 13:58:54 -0800
   # By:       Marge N. O’Vera <marge@example.com>
-  # 
+  #
   # Tag:
   #   @v1.0.0-dev1 - 2013-12-31 13:55:04 -0800 - Marge N. O’Vera <marge@example.com>
-  # 
+  #
   Nothing to deploy (up-to-date)
 
 Good, we've finished this feature. Time to merge back into C<master>.
@@ -1496,9 +1496,9 @@ scripts drop and re-create the functions with to use C<ENCRYPT()>. Make this
 change to F<deploy/insert_user.sql>:
 
   @@ -6,13 +6,14 @@ BEGIN;
- 
+
    DELIMITER //
- 
+
   +DROP PROCEDURE insert_user;
    CREATE PROCEDURE insert_user(
        nickname VARCHAR(512),
@@ -1510,14 +1510,14 @@ change to F<deploy/insert_user.sql>:
   +    VALUES (nickname, ENCRYPT(md5(password), md5(FLOOR(RAND() * 0xFFFFFFFF))), UTC_TIMESTAMP(6));
    END
    //
- 
+
 We just need to add the C<DROP> statement to the revert script,
 F<revert/insert_user.sql>:
 
   @@ -6,6 +6,7 @@ BEGIN;
- 
+
    DELIMITER //
- 
+
   +DROP PROCEDURE insert_user;
    CREATE PROCEDURE insert_user(
        nickname VARCHAR(512),
@@ -1535,9 +1535,9 @@ Go ahead and rework the C<change_pass> change, too:
 And make this change to F<deploy/change_pass.sql>:
 
   @@ -6,6 +6,7 @@ BEGIN;
- 
+
    DELIMITER //
- 
+
   +DROP FUNCTION change_pass;
    CREATE FUNCTION change_pass(
        nickname VARCHAR(512),
@@ -1558,9 +1558,9 @@ And make this change to F<deploy/change_pass.sql>:
 And add the C<DROP FUNCTION> statement to its revert script, too:
 
   @@ -6,6 +6,7 @@ BEGIN;
- 
+
    DELIMITER //
- 
+
   +DROP FUNCTION change_pass;
    CREATE FUNCTION change_pass(
        nickname VARCHAR(512),
@@ -1673,7 +1673,7 @@ Excellent. Let's go ahead and commit these changes:
   # Name:     change_pass
   # Deployed: 2013-12-31 14:16:45 -0800
   # By:       Marge N. O’Vera <marge@example.com>
-  # 
+  #
   Nothing to deploy (up-to-date)
 
 =head1 More to Come

--- a/lib/sqitchtutorial.pod
+++ b/lib/sqitchtutorial.pod
@@ -36,7 +36,7 @@ Usually the first thing to do when starting a new project is to create a
 source code repository. So let's do that with Git:
 
   > mkdir flipr
-  > cd flipr 
+  > cd flipr
   > git init .
   Initialized empty Git repository in /flipr/.git/
   > touch README.md
@@ -107,7 +107,7 @@ Back to the repository. Have a look at the plan file, F<sqitch.plan>:
   %syntax-version=1.0.0
   %project=flipr
   %uri=https://github.com/theory/sqitch-intro/
-  
+
 
 Note that it has picked up on the name and URI of the app we're building.
 Sqitch uses this data to manage cross-project dependencies. The
@@ -166,7 +166,7 @@ see the schema:
 
   > psql -d flipr_test -c '\dn flipr'
   List of schemas
-   Name  | Owner 
+   Name  | Owner
   -------+-------
    flipr | marge
 
@@ -216,7 +216,7 @@ Then L<C<verify>|sqitch-verify> again:
     * appschema .. psql:verify/appschema.sql:5: ERROR:  schema "nonesuch" does not exist
   # Verify script "verify/appschema.sql" failed.
   not ok
-  
+
   Verify Summary Report
   ---------------------
   Changes: 1
@@ -260,7 +260,7 @@ tables from the database:
   # Name:     appschema
   # Deployed: 2013-12-30 15:27:15 -0800
   # By:       Marge N. O’Vera <marge@example.com>
-  # 
+  #
   Nothing to deploy (up-to-date)
 
 Let's make sure that we can revert the change:
@@ -277,7 +277,7 @@ I<removed> from the database. And now the schema should be gone:
 
   > psql -d flipr_test -c '\dn flipr'
   List of schemas
-   Name | Owner 
+   Name | Owner
   ------+-------
 
 And the status message should reflect as much:
@@ -336,7 +336,7 @@ And now the schema should be back:
 
   > psql -d flipr_test -c '\dn flipr'
   List of schemas
-   Name  | Owner 
+   Name  | Owner
   -------+-------
    flipr | marge
 
@@ -349,7 +349,7 @@ When we look at the status, the deployment will be there:
   # Name:     appschema
   # Deployed: 2013-12-30 15:40:53 -0800
   # By:       Marge N. O’Vera <marge@example.com>
-  # 
+  #
   Nothing to deploy (up-to-date)
 
 =head1 On Target
@@ -382,7 +382,7 @@ simpler from here on in, e.g.:
   # Name:     appschema
   # Deployed: 2013-12-30 15:40:53 -0800
   # By:       Marge N. O’Vera <marge@example.com>
-  # 
+  #
   Nothing to deploy (up-to-date)
 
 Yay, that allows things to be a little more concise. Let's also make sure that
@@ -394,7 +394,7 @@ changes are verified after deploying them:
 We'll see the L<C<rebase>|sqitch-rebase> command a bit later. In the meantime,
 let's commit the new configuration and and make some more changes!
 
-  > git commit -am 'Set default deployment target and always verify.'     
+  > git commit -am 'Set default deployment target and always verify.'
   [master a6267d3] Set default deployment target and always verify.
    1 file changed, 8 insertions(+)
 
@@ -469,7 +469,7 @@ But for the purposes of visibility, let's have a quick look:
 
   > psql -d flipr_test -c '\d flipr.users'
                         Table "flipr.users"
-    Column   |           Type           |       Modifiers        
+    Column   |           Type           |       Modifiers
   -----------+--------------------------+------------------------
    nickname  | text                     | not null
    password  | text                     | not null
@@ -495,7 +495,7 @@ Now have a look at the status:
   # Name:     users
   # Deployed: 2013-12-30 15:51:09 -0800
   # By:       Marge N. O’Vera <marge@example.com>
-  # 
+  #
   Nothing to deploy (up-to-date)
 
 Success! Let's make sure we can revert the change, as well:
@@ -530,7 +530,7 @@ undeployed changes:
   # Name:     appschema
   # Deployed: 2013-12-30 15:40:53 -0800
   # By:       Marge N. O’Vera <marge@example.com>
-  # 
+  #
   Undeployed change:
     * users
 
@@ -569,7 +569,7 @@ Looks good. Check the status:
   # Name:     users
   # Deployed: 2013-12-30 15:57:14 -0800
   # By:       Marge N. O’Vera <marge@example.com>
-  # 
+  #
   Nothing to deploy (up-to-date)
 
 Excellent. Let's do some more!
@@ -614,7 +614,7 @@ F<deploy/insert_user.sql> should look like:
   -- Deploy flipr:insert_user to pg
   -- requires: users
   -- requires: appschema
-  
+
   BEGIN;
 
   CREATE OR REPLACE FUNCTION flipr.insert_user(
@@ -678,7 +678,7 @@ something like:
   -- Revert flipr:change_pass from pg
   BEGIN;
   DROP FUNCTION flipr.change_pass(TEXT, TEXT, TEXT);
-  REVERT;
+  COMMIT;
 
 Try em out!
 
@@ -692,21 +692,21 @@ look:
 
   > psql -d flipr_test -c '\df flipr.*'
                                       List of functions
-   Schema |    Name     | Result data type |          Argument data types          |  Type  
+   Schema |    Name     | Result data type |          Argument data types          |  Type
   --------+-------------+------------------+---------------------------------------+--------
    flipr  | change_pass | boolean          | nick text, oldpass text, newpass text | normal
    flipr  | insert_user | void             | nickname text, password text          | normal
 
 And what's the status?
 
-  > sqitch status 
+  > sqitch status
   # On database flipr_test
   # Project:  flipr
   # Change:   01a4f6964b89284525cb5877d222df8be70d1647
   # Name:     change_pass
   # Deployed: 2013-12-30 15:59:44 -0800
   # By:       Marge N. O’Vera <marge@example.com>
-  # 
+  #
   Nothing to deploy (up-to-date)
 
 Looks good. Let's make sure revert works:
@@ -717,7 +717,7 @@ Looks good. Let's make sure revert works:
     - insert_user .. ok
   > psql -d flipr_test -c '\df flipr.*'
                          List of functions
-   Schema | Name | Result data type | Argument data types | Type 
+   Schema | Name | Result data type | Argument data types | Type
   --------+------+------------------+---------------------+------
 
 Note the use of C<@HEAD^^> to specify that the revert be to two changes prior
@@ -733,7 +733,7 @@ the last deployed change. Looks good. Let's do the commit and re-deploy dance:
    create mode 100644 revert/insert_user.sql
    create mode 100644 verify/change_pass.sql
    create mode 100644 verify/insert_user.sql
- 
+
   > sqitch deploy
   Deploying changes to flipr_test
     + insert_user .. ok
@@ -746,9 +746,9 @@ the last deployed change. Looks good. Let's do the commit and re-deploy dance:
   # Name:     change_pass
   # Deployed: 2013-12-30 16:00:50 -0800
   # By:       Marge N. O’Vera <marge@example.com>
-  # 
+  #
   Nothing to deploy (up-to-date)
-  
+
   > sqitch verify
   Verifying flipr_test
     * appschema .... ok
@@ -793,7 +793,7 @@ C<@v1.0.0-dev1>. Let's have a look at the status:
   # Tag:      @v1.0.0-dev1
   # Deployed: 2013-12-30 16:02:19 -0800
   # By:       Marge N. O’Vera <marge@example.com>
-  # 
+  #
   Nothing to deploy (up-to-date)
 
 
@@ -903,10 +903,10 @@ Look good?
   # Name:     flips
   # Deployed: 2013-12-30 16:34:38 -0800
   # By:       Marge N. O’Vera <marge@example.com>
-  # 
+  #
   # Tag:
   #   @v1.0.0-dev1 - 2013-12-30 16:34:38 -0800 - Marge N. O’Vera <marge@example.com>
-  # 
+  #
   Nothing to deploy (up-to-date)
 
 Note the use of C<--show tags> to show all the deployed tags. Now make it so:
@@ -1015,10 +1015,10 @@ should end up looking something like this:
   # Name:     delete_flip
   # Deployed: 2013-12-30 16:37:51 -0800
   # By:       Marge N. O’Vera <marge@example.com>
-  # 
+  #
   # Tag:
   #   @v1.0.0-dev1 - 2013-12-30 16:34:38 -0800 - Marge N. O’Vera <marge@example.com>
-  # 
+  #
   Nothing to deploy (up-to-date)
 
 Good, we've finished this feature. Time to merge back into C<master>.
@@ -1140,7 +1140,7 @@ Now add the union merge driver to F<.gitattributes> for F<sqitch.plan>
 and rebase again:
 
   > echo sqitch.plan merge=union > .gitattributes
-  > git rebase master                            
+  > git rebase master
   First, rewinding head to replay your work on top of it...
   Applying: Add flips table.
   Using index info to reconstruct a base tree...
@@ -1155,7 +1155,7 @@ and rebase again:
 
 Ah, that looks a bit better. Let's have a look at the plan:
 
-  > cat sqitch.plan 
+  > cat sqitch.plan
   %syntax-version=1.0.0
   %project=flipr
   %uri=https://github.com/theory/sqitch-intro/
@@ -1247,7 +1247,7 @@ And now, finally, we can merge into C<master>:
 
 And double-check our work:
 
-  > cat sqitch.plan 
+  > cat sqitch.plan
   %syntax-version=1.0.0
   %project=flipr
   %uri=https://github.com/theory/sqitch-intro/
@@ -1275,7 +1275,7 @@ release:
   [master 230603b] Tag the database with v1.0.0-dev2.
    1 file changed, 1 insertion(+)
   > git tag v1.0.0-dev2 -am 'Tag v1.0.0-dev2'
-  > sqitch bundle --dest-dir flipr-1.0.0-dev2 
+  > sqitch bundle --dest-dir flipr-1.0.0-dev2
   Bundling into flipr-1.0.0-dev2
   Writing config
   Writing plan
@@ -1304,7 +1304,7 @@ Have a look at this:
       SELECT flipr.insert_user('foo', 'secr3t'), flipr.insert_user('bar', 'secr3t');
       SELECT * FROM flipr.users;
   "
-   nickname |             password             |           timestamp           
+   nickname |             password             |           timestamp
   ----------+----------------------------------+-------------------------------
    foo      | 9695da4dd567a19f9b92065f240c6725 | 2013-12-31 00:56:20.240481+00
    bar      | 9695da4dd567a19f9b92065f240c6725 | 2013-12-31 00:56:20.240481+00
@@ -1461,9 +1461,9 @@ F<deploy/insert_user.sql>:
    -- requires: users
    -- requires: appschema
   +-- requires: pgcrypto
- 
+
    BEGIN;
- 
+
   @@ -8,7 +9,7 @@ CREATE OR REPLACE FUNCTION flipr.insert_user(
        nickname TEXT,
        password TEXT
@@ -1471,12 +1471,12 @@ F<deploy/insert_user.sql>:
   -    INSERT INTO flipr.users VALUES($1, md5($2));
   +    INSERT INTO flipr.users values($1, crypt($2, gen_salt('md5')));
    $$;
- 
+
    COMMIT;
 
 Go ahead and rework the C<change_pass> change, too:
 
-  > sqitch rework change_pass --requires pgcrypto -n 'Change change_pass to use pgcrypto.' 
+  > sqitch rework change_pass --requires pgcrypto -n 'Change change_pass to use pgcrypto.'
   Added "change_pass [change_pass@v1.0.0-dev2 pgcrypto]" to sqitch.plan.
   Modify these files as appropriate:
     * deploy/change_pass.sql
@@ -1490,9 +1490,9 @@ And make this change to F<deploy/change_pass.sql>:
    -- requires: users
    -- requires: appschema
   +-- requires: pgcrypto
- 
+
    BEGIN;
- 
+
   @@ -11,9 +12,9 @@ CREATE OR REPLACE FUNCTION flipr.change_pass(
    ) RETURNS BOOLEAN LANGUAGE plpgsql SECURITY DEFINER AS $$
    BEGIN
@@ -1520,7 +1520,7 @@ So, are the changes deployed?
       SELECT flipr.insert_user('foo', 'secr3t'), flipr.insert_user('bar', 'secr3t');
       SELECT * FROM flipr.users;
   "
-   nickname |              password              |           timestamp           
+   nickname |              password              |           timestamp
   ----------+------------------------------------+-------------------------------
    foo      | $1$pRNfJjI9$CdcEXJ9xCoJPD.R5Z/7.R1 | 2013-12-31 01:03:15.398572+00
    bar      | $1$Nf1LcU.p$B9sKzdu8vMgu5oxbimo5P1 | 2013-12-31 01:03:15.398572+00
@@ -1540,7 +1540,7 @@ Did that work, are the C<MD5()> passwords back?
       SELECT flipr.insert_user('foo', 'secr3t'), flipr.insert_user('bar', 'secr3t');
       SELECT * FROM flipr.users;
   "
-   nickname |             password             |           timestamp           
+   nickname |             password             |           timestamp
   ----------+----------------------------------+-------------------------------
    foo      | 9695da4dd567a19f9b92065f240c6725 | 2013-12-31 01:03:57.263583+00
    bar      | 9695da4dd567a19f9b92065f240c6725 | 2013-12-31 01:03:57.263583+00
@@ -1608,7 +1608,7 @@ Excellent. Let's go ahead and commit these changes:
   # Name:     change_pass
   # Deployed: 2013-12-30 17:05:08 -0800
   # By:       Marge N. O’Vera <marge@example.com>
-  # 
+  #
   Nothing to deploy (up-to-date)
 
 =head1 More to Come


### PR DESCRIPTION
There were two `REVERT`s instead of `COMMIT` in the docs. Also vim stripped whitespaces at the end of the lines and left it like this, it seems much nicer this way.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/theory/sqitch/266)
<!-- Reviewable:end -->
