### PR TITLE
Fix typo in sqitch revert usage documentation

### DIFF
--- a/lib/sqitch-revert-usage.pod
+++ b/lib/sqitch-revert-usage.pod
@@ -4,7 +4,7 @@ sqitch-revert-usage - Sqitch revert usage statement
 
 =head1 Usage
 
-  sqitch [options] revert [change options] [<datbase>]
+  sqitch [options] revert [change options] [<database>]
 
 =head1 Options
 


### PR DESCRIPTION
This fixes a minor typo I spotted while reading the `sqitch revert` docs.

This PR is submitted in the hope that it is helpful.  Comments and/or questions concerning the PR are most welcome!