### PR TITLE
Read dos-formatted config files correctly on unix

### DIFF
--- a/lib/App/Sqitch/Config.pm
+++ b/lib/App/Sqitch/Config.pm
@@ -17,6 +17,15 @@ our $VERSION = '0.9994';
 has '+confname' => ( default => 'sqitch.conf' );
 has '+encoding' => ( default => 'UTF-8' );
 
+after 'load_file' => sub {
+    my $self = shift;
+    return unless ref $self;
+    return unless $self->data;
+    for my $key (keys %{$self->data}) {
+        $self->data->{$key} =~ s/\cM$//;
+    }
+};
+
 # Set by ./Build; see Module::Build::Sqitch for details.
 my $SYSTEM_DIR = undef;
 

--- a/t/sqitch_dos.conf
+++ b/t/sqitch_dos.conf
@@ -1,0 +1,18 @@
+[core]
+    uri       = https://github.com/theory/sqitch/
+    engine    = pg
+    top_dir   = migrations
+    extension = ddl
+
+[engine "pg"]
+    client    = /usr/local/pgsql/bin/psql
+
+[revert]
+    to        = gamma
+    count     = 2
+    revision  = 1.1
+
+[bundle]
+    from      = gamma
+    tags_only = true
+    dest_dir  = _build/sql


### PR DESCRIPTION
It turns out that an extra `^M` character appears at the end of
configuration values read in from e.g. `sqitch.conf` if the configuration
file uses dos-style line endings and the system reading the file is
Unix-based.  The trailing control character caused files and paths from
`Path::Class` to be mis-represented and thus for various other files to not
be found.  In the particular example where this was found, the configuration
for `top_dir` was: `top_dir = sqitch`, which caused the string
representation of `plan_file` (expected to be called `sqitch/sqitch.plan`)
to be `/sqitch.plan`.  The `^M` caused a carriage return and thus overwrote
the directory portion, `sqitch`, (generated from `top_dir`) to be overwritten
with the directory separator and file name part of `plan_file`.  In other
words the path `sqitch^M/sqitch.plan` was returned as `/sqitch.plan`.

The example input configuration file and test in this commit expose this
issue; the changes in `App::Sqitch::Config` correct the problem by removing
superfluous `^M` characters in the data loaded from file as part of
`Config::GitLike`'s `load_file` method.  This certainly fixes the problem,
however there might be a more appropriate location for the fix.

This patch also fixes two corner use-cases: when the input configuration
file happens to contain dos-style line endings, and when sqitch is used in a
Unix-based virtual machine running on Windows and using directories shared
with the host system.  In particular, the issue addressed here was found
when using sqitch in Debian Jessie guest system while using a shared
directory from a Windows 7 host system.  Hence, one is now able to use
sqitch in the guest system even though the project files hosted on the host
system use dos-style line endings.

This PR is submitted in the hope that it is helpful.  If you have any questions or comments about it, please just ask!  If the changes I've made in the PR don't meet your coding standards or if there is something which you feel ought be changed, please just let me know and I'll update the PR as appropriate.