### PR TITLE
Fix spelling for PostgreSQL

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,14 +69,14 @@ from your typical <a href="http://guides.rubyonrails.org/migrations.html">migrat
 <h4 id="docker"><a href="https://registry.hub.docker.com/u/docteurklein/sqitch/">Docker</a></h4>
 
 <ul>
-  <li>PostreSQL: <code>docker run --rm docteurklein/sqitch:pgsql</code></li>
+  <li>PostgreSQL: <code>docker run --rm docteurklein/sqitch:pgsql</code></li>
 </ul>
 
 <h4 id="homebrew"><a href="http://brew.sh">Homebrew</a></h4>
 
 <ul>
   <li>Tap: <code>brew tap theory/sqitch</code></li>
-  <li>PostreSQL: <code>brew install sqitch_pg</code></li>
+  <li>PostgreSQL: <code>brew install sqitch_pg</code></li>
   <li>SQLite: <code>brew install sqitch_sqlite</code></li>
   <li>Oracle: <code>brew install sqitch_oracle</code></li>
   <li>MySQL: <code>brew install sqitch_mysql</code></li>
@@ -88,7 +88,7 @@ from your typical <a href="http://guides.rubyonrails.org/migrations.html">migrat
 
 <ul>
   <li>Apt: <code>apt-get install sqitch</code></li>
-  <li>PostreSQL: <code>apt-get install libdbd-pg-perl postgresql-client</code></li>
+  <li>PostgreSQL: <code>apt-get install libdbd-pg-perl postgresql-client</code></li>
   <li>SQLite: <code>apt-get install libdbd-sqlite3-perl sqlite3</code></li>
   <li>Oracle: <code>apt-get install libdbd-oracle-perl</code></li>
   <li>MySQL: <code>apt-get install libdbd-mysql-perl mysql-client</code></li>
@@ -118,7 +118,7 @@ from your typical <a href="http://guides.rubyonrails.org/migrations.html">migrat
 <ul>
   <li>Apt: <code>apt-get install build-essential cpanminus perl perl-doc</code></li>
   <li>Sqitch: <code>cpanm --quiet --notest App::Sqitch</code></li>
-  <li>PostreSQL: <code>apt-get install postgresql libdbd-pg-perl</code></li>
+  <li>PostgreSQL: <code>apt-get install postgresql libdbd-pg-perl</code></li>
   <li>SQLite: <code>apt-get install sqlite libdbd-sqlite3-perl</code></li>
   <li>Oracle: <code>apt-get install libdbd-oracle-perl</code></li>
   <li>MySQL: <code>apt-get install mysql libdbd-mysql-perl</code></li>
@@ -132,7 +132,7 @@ from your typical <a href="http://guides.rubyonrails.org/migrations.html">migrat
   <li>Yum: <code>sudo yum install perl-devel perl-CPAN \<br />
       && curl -L http://cpanmin.us | perl - --sudo App::cpanminus</code></li>
   <li>Sqitch: <code>cpanm --quiet --notest App::Sqitch</code></li>
-  <li>PostreSQL: <code>yum install postgresql perl-DBD-Pg</code></li>
+  <li>PostgreSQL: <code>yum install postgresql perl-DBD-Pg</code></li>
   <li>SQLite: <code>yum install sqlite perl-DBD-SQLite</code></li>
   <li>Oracle: <code>yum install perl-DBD-Oracle</code></li>
   <li>MySQL: <code>yum install mysql perl-DBD-mysql</code></li>


### PR DESCRIPTION
This fixes a few instances on the page where "PostgreSQL" was mistakenly spelled as "PostreSQL".

Have a good day!