### PR TITLE
update registry configuration demo for mysql tutorial

### DIFF
--- a/lib/sqitchtutorial-mysql.pod
+++ b/lib/sqitchtutorial-mysql.pod
@@ -68,8 +68,10 @@ Let's have a look at F<sqitch.conf>:
   	# top_dir = .
   # [engine "mysql"]
   	# target = db:mysql:
-  	# registry = sqitch
   	# client = /usr/local/mysql/bin/mysql
+  # [target "flipr"]
+    # registry = sqitch
+    # uri = db:mysql://root:@127.0.0.1/flipr
 
 Good, it picked up on the fact that we're creating changes for the MySQL
 engine, thanks to the C<--engine mysql> option, and saved it to the file.


### PR DESCRIPTION
seems like the latest version moved registry configuration to be under target section, caused lots of time to track it :(, this doc should be updated.