### PR TITLE
Allow non-superuser to create sqitch.

### DIFF
--- a/lib/App/Sqitch/Engine/pg.pm
+++ b/lib/App/Sqitch/Engine/pg.pm
@@ -157,7 +157,7 @@ sub initialized {
     my $self = shift;
     return $self->dbh->selectcol_arrayref(q{
         SELECT EXISTS(
-            SELECT TRUE FROM pg_catalog.pg_namespace WHERE nspname = ?
+            SELECT TRUE FROM pg_catalog.pg_tables WHERE schemaname = ? AND tablename = changes
         )
     }, undef, $self->registry)->[0];
 }

--- a/lib/App/Sqitch/Engine/pg.pm
+++ b/lib/App/Sqitch/Engine/pg.pm
@@ -157,9 +157,9 @@ sub initialized {
     my $self = shift;
     return $self->dbh->selectcol_arrayref(q{
         SELECT EXISTS(
-            SELECT TRUE FROM pg_catalog.pg_tables WHERE schemaname = ? AND tablename = changes
+            SELECT TRUE FROM pg_catalog.pg_tables WHERE schemaname = ? AND tablename = ?
         )
-    }, undef, $self->registry)->[0];
+    }, undef, $self->registry,'changes')->[0];
 }
 
 sub initialize {

--- a/lib/App/Sqitch/Engine/pg.sql
+++ b/lib/App/Sqitch/Engine/pg.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
 SET client_min_messages = warning;
-CREATE SCHEMA :"registry";
+CREATE SCHEMA IF NOT EXISTS :"registry";
 
 COMMENT ON SCHEMA :"registry" IS 'Sqitch database deployment metadata v1.0.';
 

--- a/t/lib/upgradable_registries/pg.sql
+++ b/t/lib/upgradable_registries/pg.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
 SET client_min_messages = warning;
-CREATE SCHEMA :"registry";
+CREATE SCHEMA IF NOT EXISTS :"registry";
 
 COMMENT ON SCHEMA :"registry" IS 'Sqitch database deployment metadata v1.0.';
 


### PR DESCRIPTION
I'm rather careful to not use superusers when I don't have to. I have been able to avoid needing superuser status for deployments by giving users ownership over their own schemas etc. I ran into trouble deploying sqitch because it would error if the schema was already created.

The basic use case is, as a superuser, I would like to be able to run: 
CREATE SCHEMA sqitch AUTHORIZATION sqitch_user;

then when connected as sqitch_user, I want sqitch to deploy as normal, the problem is it errored completely if the schema already exists. If it exists, I would prefer it continue. If I had failed to give it ownership of the schema, further bits would fail (commenting, creating tables etc.) but this allows for this use case to work and for the sqitch_user not to need superuser privileges. (I can grant it privileges on other schemas that it needs to work in otherwise).

Let me know if there are any troubles with this. 
