### PR TITLE
remove `no Moo::sification;`

### DIFF
--- a/dist/sqitch.spec
+++ b/dist/sqitch.spec
@@ -40,7 +40,6 @@ BuildRequires:  perl(Locale::TextDomain) >= 1.20
 BuildRequires:  perl(Module::Build) >= 0.35
 BuildRequires:  perl(Moo) >= 1.002000
 BuildRequires:  perl(Moo::Role)
-BuildRequires:  perl(Moo::sification)
 BuildRequires:  perl(namespace::autoclean) >= 0.16
 BuildRequires:  perl(parent)
 BuildRequires:  perl(overload)
@@ -106,7 +105,6 @@ Requires:       perl(List::MoreUtils)
 Requires:       perl(Locale::TextDomain) >= 1.20
 Requires:       perl(Moo) => 1.002000
 Requires:       perl(Moo::Role)
-Requires:       perl(Moo::sification)
 Requires:       perl(namespace::autoclean) >= 0.16
 Requires:       perl(parent)
 Requires:       perl(overload)

--- a/lib/App/Sqitch.pm
+++ b/lib/App/Sqitch.pm
@@ -6,7 +6,6 @@ use 5.010;
 use strict;
 use warnings;
 use utf8;
-no Moo::sification;
 use Getopt::Long;
 use Hash::Merge qw(merge);
 use Path::Class;

--- a/t/mooseless.t
+++ b/t/mooseless.t
@@ -4,12 +4,9 @@ use strict;
 use warnings;
 use utf8;
 use Test::More;
-use Module::Runtime qw(use_module);
-use Test::Exception;
 
-no Moo::sification;
+use App::Sqitch;
 
-lives_ok { use_module 'App::Sqitch';  };
-
+ok ! exists($INC{'Moose.pm'}), 'no moose here';
 
 done_testing();

--- a/t/mooseless.t
+++ b/t/mooseless.t
@@ -1,0 +1,15 @@
+#!/usr/bin/perl -w
+
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use Module::Runtime qw(use_module);
+use Test::Exception;
+
+no Moo::sification;
+
+lives_ok { use_module 'App::Sqitch';  };
+
+
+done_testing();

--- a/t/mooseless.t
+++ b/t/mooseless.t
@@ -3,10 +3,29 @@
 use strict;
 use warnings;
 use utf8;
+
 use Test::More;
+use File::Find qw(find);
+use Module::Runtime qw(use_module);
 
-use App::Sqitch;
+my $test = sub {
+    return unless $_ =~ /\.pm$/;
 
-ok ! exists($INC{'Moose.pm'}), 'no moose here';
+	my $module = $File::Find::name;
+	$module =~ s!^(blib[/\\])?lib[/\\]!!;
+	$module =~ s![/\\]!::!g;
+	$module =~ s/\.pm$//;
+
+    eval { use_module $module; };
+    if ($@) {
+        diag "Couldn't load $module: $@";
+        undef $@;
+        return;
+    }
+
+    ok ! $INC{'Moose.pm'}, "No moose in $module";
+};
+
+find($test, 'lib');
 
 done_testing();


### PR DESCRIPTION
Enforcing the Moo-only-ness of `App::sqitch` leads to killing use cases where using `App::Sqitch` programmatically from inside (for example) a test suite to set up the test environment failed if at any point something (say Catalyst) was to load Moose previously.