### PR TITLE
List all options in sqitch-rework.pod

### DIFF
--- a/lib/sqitch-rework-usage.pod
+++ b/lib/sqitch-rework-usage.pod
@@ -8,8 +8,14 @@ sqitch-rework-usage - Sqitch rework usage statement
 
 =head1 Options
 
-    -r --requires             require change
-    -x --conflicts            declare conflicting change
-    -n --note                 a note describing the change
+    -r --requires               require change
+    -x --conflicts              declare conflicting change
+    -n --note                   a note describing the change
 
-    -e --edit, --open-editor  open change scripts in an editor
+    -c --change --change-name   name of the change to rework
+
+    -a --all                    rework the change in all plans in the project
+
+    -e --edit --open-editor     open change scripts in an editor
+    --no-edit --no-open-editor  do not open the change scripts in an editor
+


### PR DESCRIPTION
So command line help matches longer docs in terms
of at least listing all the switches.