### PR TITLE
Italian Translation

### DIFF
--- a/po/it_IT.po
+++ b/po/it_IT.po
@@ -291,7 +291,7 @@ msgstr ""
 #: lib/App/Sqitch/Command/deploy.pm:118
 #, perl-brace-format
 msgid "Too many changes specified; deploying to \"{change}\""
-msgstr "Troppi cambiamenti specificati: deploy per \"{change}\""
+msgstr "Troppi cambiamenti specificati; implementazione a \"{change}\""
 
 #: lib/App/Sqitch/Command/engine.pm:34 lib/App/Sqitch/Command/engine.pm:184
 #: lib/App/Sqitch/Command/engine.pm:261
@@ -372,7 +372,7 @@ msgstr "Ripristina"
 #: lib/App/Sqitch/Command/engine.pm:283 lib/App/Sqitch/Command/target.pm:261
 #: lib/App/Sqitch/ItemFormatter.pm:61
 msgid "Deploy"
-msgstr "Deploy"
+msgstr "Implementa"
 
 #: lib/App/Sqitch/Command/engine.pm:284 lib/App/Sqitch/Command/target.pm:262
 msgid "Verify"
@@ -648,8 +648,8 @@ msgstr "Niente da implementare (tutto già aggiornato)"
 #: lib/App/Sqitch/Command/status.pm:308 lib/App/Sqitch/Engine.pm:495
 msgid "Undeployed change:"
 msgid_plural "Undeployed changes:"
-msgstr[0] "Modifica rimosse dal deploy:"
-msgstr[1] "Modifiche rimosse dal deploy:"
+msgstr[0] "Modifica rimosse dalla implementazione:"
+msgstr[1] "Modifiche rimosse dalla implementazione:"
 
 #: lib/App/Sqitch/Command/tag.pm:80
 msgid "tag"
@@ -726,7 +726,7 @@ msgstr "{driver} è necessario per gestire {engine}"
 
 #: lib/App/Sqitch/Engine.pm:159
 msgid "Nothing to deploy (empty plan)"
-msgstr "Niente da dployare (piano esecuzione vuoto)"
+msgstr "Niente da implementare (piano di esecuzione vuoto)"
 
 #: lib/App/Sqitch/Engine.pm:163 lib/App/Sqitch/Engine.pm:256
 #: lib/App/Sqitch/Plan.pm:735 lib/App/Sqitch/Plan/ChangeList.pm:155
@@ -746,32 +746,32 @@ msgstr "Aggiungo le tabelle di registro a {destination}"
 
 #: lib/App/Sqitch/Engine.pm:197
 msgid "Cannot deploy to an earlier change; use \"revert\" instead"
-msgstr "Non posso effettuare deploy a una modifica precedente; usa \"revert\"."
+msgstr "Non posso implementare una modifica precedente; usa \"revert\"."
 
 #: lib/App/Sqitch/Engine.pm:205
 #, perl-brace-format
 msgid "Deploying changes through {change} to {destination}"
-msgstr "Eseguo deploy delle modifiche da {change} a {destination}"
+msgstr "Implementazione delle modifiche da {change} a {destination}"
 
 #: lib/App/Sqitch/Engine.pm:209
 #, perl-brace-format
 msgid "Deploying changes to {destination}"
-msgstr "Effettuo deploy modifiche a {destination}"
+msgstr "Implementazione delle modifiche a {destination}"
 
 #: lib/App/Sqitch/Engine.pm:222
 #, perl-brace-format
 msgid "Unknown deployment mode: \"{mode}\""
-msgstr "Modalità di deploy \"{mode}\" sconosciuta"
+msgstr "Modalità di implementazione \"{mode}\" sconosciuta"
 
 #: lib/App/Sqitch/Engine.pm:250
 #, perl-brace-format
 msgid "Change not deployed: \"{change}\""
-msgstr "Modifica non inclusa nel deploy: \"{change}\""
+msgstr "Modifica non implementata: \"{change}\""
 
 #: lib/App/Sqitch/Engine.pm:266
 #, perl-brace-format
 msgid "No changes deployed since: \"{change}\""
-msgstr "Nessuna modifica per cui effettuare deploy da \"{change}\""
+msgstr "Nessuna modifica implementata da: \"{change}\""
 
 #: lib/App/Sqitch/Engine.pm:274
 #, perl-brace-format
@@ -789,7 +789,7 @@ msgstr "Annullo modifiche da {destination} a {change}"
 
 #: lib/App/Sqitch/Engine.pm:293
 msgid "Nothing to revert (nothing deployed)"
-msgstr "Niente da annullare (niente per cui effettuare deploy)"
+msgstr "Niente da annullare (niente da implementare)"
 
 #: lib/App/Sqitch/Engine.pm:299
 #, perl-brace-format
@@ -809,12 +809,11 @@ msgstr "Veifico {destination}"
 #: lib/App/Sqitch/Engine.pm:347
 msgid "Nothing to verify (no planned or deployed changes)"
 msgstr ""
-"Niente da verificare (nessuna modifica pianificata o per cui effettuare "
-"deploy)"
+"Niente da verificare (nessuna modifica pianificata o implementata)"
 
 #: lib/App/Sqitch/Engine.pm:357
 msgid "There are deployed changes, but none planned!"
-msgstr "Ci sono modifiche incluse nel deploy, ma nessuna pianificata!"
+msgstr "Ci sono modifiche implementate, ma nessuna pianificata!"
 
 #: lib/App/Sqitch/Engine.pm:377
 msgid "Verify Summary Report"
@@ -951,7 +950,7 @@ msgstr "Lo schema richiede una riparazione manuale."
 
 #: lib/App/Sqitch/Engine.pm:815 lib/App/Sqitch/Engine.pm:957
 msgid "Deploy failed"
-msgstr "Deploy fallito"
+msgstr "Implementazione fallita"
 
 #: lib/App/Sqitch/Engine.pm:872
 #, perl-brace-format
@@ -967,7 +966,7 @@ msgstr "Aggiorno la modifica legacy e gli ID dei tag in {destination}"
 #, perl-brace-format
 msgid "No registry found in {destination}. Have you ever deployed?"
 msgstr ""
-"Nessun registro trovato in {destination}. E' mai stato fatto un deploy prima?"
+"Nessun registro trovato in {destination}. E' mai stata fatta una implementazione prima?"
 
 #: lib/App/Sqitch/Engine.pm:1031
 #, perl-brace-format
@@ -1099,7 +1098,7 @@ msgstr "Fallito"
 
 #: lib/App/Sqitch/ItemFormatter.pm:68
 msgid "deploy"
-msgstr "deploy"
+msgstr "implementa"
 
 #: lib/App/Sqitch/ItemFormatter.pm:69
 msgid "revert"

--- a/po/it_IT.po
+++ b/po/it_IT.po
@@ -1119,7 +1119,7 @@ msgstr "Modifica:"
 
 #: lib/App/Sqitch/ItemFormatter.pm:77
 msgid "Committer:"
-msgstr "Committer:"
+msgstr "Autore:"
 
 #: lib/App/Sqitch/ItemFormatter.pm:78
 #, fuzzy

--- a/po/it_IT.po
+++ b/po/it_IT.po
@@ -309,7 +309,7 @@ msgstr "Azione sconosciuta: \"{action}\""
 #, perl-brace-format
 msgid "Cannot assign URI using engine \"{new}\" to engine \"{old}\""
 msgstr ""
-"Non posso assegnare nessun URI usando l'engine da \"{new}\" a \"{old}\""
+"Non posso assegnare nessun URI usando il motore da \"{new}\" a \"{old}\""
 
 #: lib/App/Sqitch/Command/engine.pm:90 lib/App/Sqitch/Command/engine.pm:208
 #: lib/App/Sqitch/Command/target.pm:140 lib/App/Sqitch/Command/target.pm:240
@@ -320,16 +320,16 @@ msgstr "Target sconosciuto: \"{target}\""
 #: lib/App/Sqitch/Command/engine.pm:104
 #, perl-brace-format
 msgid "Engine \"{engine}\" already exists"
-msgstr "L'engine \"{engine}\" esiste già"
+msgstr "Il motore \"{engine}\" esiste già"
 
 #: lib/App/Sqitch/Command/engine.pm:143
 #, perl-brace-format
 msgid "Missing Engine \"{engine}\"; use \"{command}\" to add it"
-msgstr "Engine mancante:\"{engine}\"; usa \"{command}\" per aggiungerlo"
+msgstr "Motore mancante:\"{engine}\"; usa \"{command}\" per aggiungerlo"
 
 #: lib/App/Sqitch/Command/engine.pm:152
 msgid "Cannot unset an engine target"
-msgstr "Non posso invalidare un target di tipo engine"
+msgstr "Non posso invalidare un target di tipo motore"
 
 #: lib/App/Sqitch/Command/engine.pm:174 lib/App/Sqitch/Command/target.pm:131
 #, perl-brace-format
@@ -406,7 +406,7 @@ msgstr ""
 
 #: lib/App/Sqitch/Command/engine.pm:359
 msgid "  - No engines to update"
-msgstr " - Nessun engine da aggiornare"
+msgstr " - Nessun motore da aggiornare"
 
 #: lib/App/Sqitch/Command/engine.pm:366
 #, perl-brace-format

--- a/po/it_IT.po
+++ b/po/it_IT.po
@@ -85,7 +85,7 @@ msgstr[1] "Argomenti sconosciuti: {arg}"
 #: lib/App/Sqitch/Command.pm:276
 msgid "Cannot specify both --all and engine, target, or plan arugments"
 msgstr ""
-"Non si puo' specificare contemporaneamente --all e engine, target o plan."
+"Non si può specificare contemporaneamente --all e target, target o plan."
 
 #: lib/App/Sqitch/Command/add.pm:102
 #, perl-brace-format

--- a/po/it_IT.po
+++ b/po/it_IT.po
@@ -95,7 +95,7 @@ msgstr "Il template {template} non esiste"
 #: lib/App/Sqitch/Command/add.pm:107
 #, perl-brace-format
 msgid "Template {template} is not a file"
-msgstr "Il tempalte {template} non è un file"
+msgstr "Il template {template} non è un file"
 
 #: lib/App/Sqitch/Command/add.pm:153
 #, perl-brace-format
@@ -143,7 +143,7 @@ msgstr "\"{change}\" aggiunta al file {file}"
 #: lib/App/Sqitch/Command/add.pm:407
 #, perl-brace-format
 msgid "Skipped {file}: already exists"
-msgstr "Salto {file}: esistente"
+msgstr "Saltato {file}: esiste già"
 
 #: lib/App/Sqitch/Command/add.pm:418 lib/App/Sqitch/Command/bundle.pm:141
 #: lib/App/Sqitch/Role/TargetConfigCommand.pm:261
@@ -183,7 +183,7 @@ msgid ""
 "Use of --to or --from to bundle multiple targets is not recommended.\n"
 "Pass them as arguments after each target argument, instead."
 msgstr ""
-"L'uso di --to o --from per creare un bundle con piu' target è sconsigliato.\n"
+"L'uso di --to o --from per creare un bundle con più target è sconsigliato.\n"
 "Passali come argomenti dopo ogni target."
 
 #: lib/App/Sqitch/Command/bundle.pm:106
@@ -240,7 +240,7 @@ msgstr "Salvo gli script"
 #: lib/App/Sqitch/Command/verify.pm:94
 #, perl-brace-format
 msgid "Too many targets specified; connecting to {target}"
-msgstr "Troppo pochi target specificati: collegamento a {target}"
+msgstr "Troppo  target specificati: collegamento a {target}"
 
 #: lib/App/Sqitch/Command/checkout.pm:63
 #, perl-brace-format
@@ -266,19 +266,19 @@ msgstr "Azione di configurazione sconosciuta: {action}"
 #: lib/App/Sqitch/Command/config.pm:149
 #, perl-brace-format
 msgid "More then one value for the key \"{key}\""
-msgstr "Piu' di un valore per la chiave \"{key}\""
+msgstr "Più di un valore per la chiave \"{key}\""
 
 #: lib/App/Sqitch/Command/config.pm:261
 msgid "Cannot overwrite multiple values with a single value"
-msgstr "Non posso sovrascrivere piu' valori con un singolo valore"
+msgstr "Non posso sovrascrivere più valori con un singolo valore"
 
 #: lib/App/Sqitch/Command/config.pm:291
 msgid "Cannot unset key with multiple values"
-msgstr "Non posso invalidare una chiave con multipli valori"
+msgstr "Non posso invalidare una chiave con  valori multipli"
 
 #: lib/App/Sqitch/Command/config.pm:344 lib/App/Sqitch/Command/config.pm:361
 msgid "No such section!"
-msgstr "Non esiste la sezione!"
+msgstr "Questa sezione non esiste!"
 
 #: lib/App/Sqitch/Command/deploy.pm:85 lib/App/Sqitch/Command/revert.pm:80
 msgid ""
@@ -298,7 +298,7 @@ msgstr "Troppi cambiamenti specificati: deploy per \"{change}\""
 #: lib/App/Sqitch/Role/TargetConfigCommand.pm:112
 #, perl-brace-format
 msgid "Unknown engine \"{engine}\""
-msgstr "Engine sconosciuto: \"{engine}\""
+msgstr "Motore sconosciuto: \"{engine}\""
 
 #: lib/App/Sqitch/Command/engine.pm:50 lib/App/Sqitch/Command/target.pm:43
 #, perl-brace-format
@@ -419,7 +419,7 @@ msgid ""
 "Migrated {old} to {new}; To remove {old}, run\n"
 "    {sqitch} config --file {file} --remove-section {old}"
 msgstr ""
-"MIgraziene da {old} a {new} completata. Per rimuovere {old} esegui\n"
+"MIgrazioIne da {old} a {new} completata. Per rimuovere {old} esegui\n"
 "    {sqitch} config --file {file} --remove-section {old}"
 
 #: lib/App/Sqitch/Command/help.pm:46
@@ -434,10 +434,10 @@ msgid ""
 "punctuation, contain \"@\", \":\", \"#\", or blanks, or end in punctuation "
 "or digits following punctuation"
 msgstr ""
-"Il nome di progetto \"{project}\" non è valido: I nomi di progetto non "
+"Il nome di progetto \"{project}\" non è valido: i nomi di progetto non "
 "possono iniziare con punteggiarura, contenere \"@\", \":\", \"#\", o spazi "
 "bianchi e non possono terminare con simboli di punteggiatura o numeri dopo "
-"dopo la punteggiatura."
+"la punteggiatura."
 
 #: lib/App/Sqitch/Command/log.pm:174
 #, perl-brace-format
@@ -507,7 +507,7 @@ msgstr "rilavoro"
 #: lib/App/Sqitch/Command/rework.pm:171
 #, perl-brace-format
 msgid "Added \"{change}\" to {file}."
-msgstr "\"{change}\" aggiunta a {file}."
+msgstr "\"{change}\" aggiunto a {file}."
 
 #: lib/App/Sqitch/Command/rework.pm:179
 msgid "Modify this file as appropriate:"
@@ -518,7 +518,7 @@ msgstr[1] "Modifica questi file nel modo appropriato:"
 #: lib/App/Sqitch/Command/rework.pm:199
 #, perl-brace-format
 msgid "Skipped {dest}: {src} does not exist"
-msgstr "Salto {dest}: {src} non esiste"
+msgstr "Saltato {dest}: {src} non esiste"
 
 #: lib/App/Sqitch/Command/rework.pm:208
 #, perl-brace-format
@@ -566,7 +566,7 @@ msgstr "Nessun progetto registrato"
 #: lib/App/Sqitch/Command/status.pm:79
 #, perl-brace-format
 msgid "Use --project to select which project to query: {projects}"
-msgstr "Usa --project per selezionare  quale progetto interrogare: {projects}"
+msgstr "Usa --project per selezionare quale progetto interrogare: {projects}"
 
 #: lib/App/Sqitch/Command/status.pm:80 lib/App/Sqitch/Command/status.pm:203
 #: lib/App/Sqitch/Role/TargetConfigCommand.pm:95
@@ -575,7 +575,7 @@ msgstr ","
 
 #: lib/App/Sqitch/Command/status.pm:135 lib/App/Sqitch/Engine.pm:346
 msgid "No changes deployed"
-msgstr "Nessuna modifica deployata"
+msgstr "Nessuna modifica implementata"
 
 #: lib/App/Sqitch/Command/status.pm:153
 #, perl-brace-format
@@ -608,7 +608,7 @@ msgstr[1] "Tag:      {tags}"
 #: lib/App/Sqitch/Command/status.pm:208
 #, perl-brace-format
 msgid "Deployed: {date}"
-msgstr "Deployato: {date}"
+msgstr "Implementazione: {date}"
 
 #: lib/App/Sqitch/Command/status.pm:214
 #, perl-brace-format
@@ -643,7 +643,7 @@ msgstr ""
 
 #: lib/App/Sqitch/Command/status.pm:305 lib/App/Sqitch/Engine.pm:179
 msgid "Nothing to deploy (up-to-date)"
-msgstr "Niente da deployare (tutto già aggiornato)"
+msgstr "Niente da implementare (tutto già aggiornato)"
 
 #: lib/App/Sqitch/Command/status.pm:308 lib/App/Sqitch/Engine.pm:495
 msgid "Undeployed change:"
@@ -737,7 +737,7 @@ msgstr "Modifica \"{change}\" sconosciuta"
 #: lib/App/Sqitch/Engine.pm:170
 #, perl-brace-format
 msgid "Nothing to deploy (already at \"{change}\")"
-msgstr "Niente da deployare (già a \"{change}\")"
+msgstr "Niente da implementare (già a \"{change}\")"
 
 #: lib/App/Sqitch/Engine.pm:188
 #, perl-brace-format
@@ -841,7 +841,7 @@ msgstr "Verifica riuscita"
 #: lib/App/Sqitch/Engine.pm:400
 #, perl-brace-format
 msgid "Change \"{change}\" has not been deployed"
-msgstr "Modifica \"{change}\" non deployata"
+msgstr "Modifica \"{change}\" non implementata"
 
 #: lib/App/Sqitch/Engine.pm:403
 #, perl-brace-format
@@ -851,7 +851,7 @@ msgstr "Non posso trovare \"{change}\" nel database o nel piano di esecuzione"
 #: lib/App/Sqitch/Engine.pm:410
 #, perl-brace-format
 msgid "Change \"{change}\" is deployed, but not planned"
-msgstr "La modifica \"{change}\" è deployata ma non pianificata"
+msgstr "La modifica \"{change}\" è implementata ma non pianificata"
 
 #: lib/App/Sqitch/Engine.pm:454
 msgid "Out of order"
@@ -873,7 +873,7 @@ msgstr "OK"
 
 #: lib/App/Sqitch/Engine.pm:485
 msgid "Not deployed"
-msgstr "Non deployato"
+msgstr "Non implementato"
 
 #: lib/App/Sqitch/Engine.pm:517
 #, perl-brace-format
@@ -890,9 +890,9 @@ msgstr "Lo script di verifica {file} non esiste"
 msgid "Conflicts with previously deployed change: {changes}"
 msgid_plural "Conflicts with previously deployed changes: {changes}"
 msgstr[0] ""
-"Ci sono conflitti con la modifica precdedentemente deployata: {changes}"
+"Ci sono conflitti con la modifica precdedentemente implementata: {changes}"
 msgstr[1] ""
-"Ci sono conflitti con le modifiche precdedentemente deployate: {changes}"
+"Ci sono conflitti con le modifiche precededentemente implementate: {changes}"
 
 #: lib/App/Sqitch/Engine.pm:574
 #, perl-brace-format
@@ -905,8 +905,8 @@ msgstr[1] "Modifiche richieste non trovate: {changes}"
 #, perl-brace-format
 msgid "Change \"{changes}\" has already been deployed"
 msgid_plural "Changes have already been deployed: {changes}"
-msgstr[0] "La modifica \"{changes}\" è già stata deployata"
-msgstr[1] "Le modifiche \"{changes}\" sono già state deployate"
+msgstr[0] "La modifica \"{changes}\" è già stata implementata"
+msgstr[1] "Le modifiche \"{changes}\" sono già state implementate"
 
 #: lib/App/Sqitch/Engine.pm:609
 #, perl-brace-format
@@ -914,11 +914,11 @@ msgid "Change \"{change}\" required by currently deployed change: {changes}"
 msgid_plural ""
 "Change \"{change}\" required by currently deployed changes: {changes}"
 msgstr[0] ""
-"La modifica \"{change}\" è richiesta dalla modifica correntemente deployata: "
+"La modifica \"{change}\" è richiesta dalla modifica correntemente implementata: "
 "{changes}"
 msgstr[1] ""
 "La modifica \"{change}\" è richiesta dalle modifiche correntemente "
-"deployate: {changes}"
+"implementate: {changes}"
 
 #: lib/App/Sqitch/Engine.pm:632
 #, perl-brace-format
@@ -975,7 +975,7 @@ msgid ""
 "Registry version is {old} but {new} is the latest known. Please upgrade "
 "Sqitch"
 msgstr ""
-"La versione di registro è {old} ma {new} è la piu' recente conosciuta. Per "
+"La versione di registro è {old} ma {new} è la più recente conosciuta. Per "
 "favore aggiorna Sqitch."
 
 #: lib/App/Sqitch/Engine.pm:1037
@@ -984,7 +984,7 @@ msgid ""
 "Registry is at version {old} but latest is {new}. Please run the \"upgrade\" "
 "conmand"
 msgstr ""
-"La versione di registro è {old} ma {new} è la piu' recente conosciuta. Per "
+"La versione di registro è {old} ma {new} è la più recente conosciuta. Per "
 "favore esegui il comando \"upgrade\"."
 
 #: lib/App/Sqitch/Engine.pm:1052
@@ -993,7 +993,7 @@ msgid ""
 "Registry version is {old} but {new} is the latest known. Please upgrade "
 "Sqitch."
 msgstr ""
-"La versione di registro è {old} ma {new} è la piu' recente conosciuta. Per "
+"La versione di registro è {old} ma {new} è la più recente conosciuta. Per "
 "favore aggiorna Sqitch."
 
 #: lib/App/Sqitch/Engine.pm:1067

--- a/po/it_IT.po
+++ b/po/it_IT.po
@@ -1135,7 +1135,7 @@ msgstr "Data:"
 
 #: lib/App/Sqitch/ItemFormatter.pm:81
 msgid "Committed:"
-msgstr "Committato:"
+msgstr "Creata:"
 
 #: lib/App/Sqitch/ItemFormatter.pm:82
 msgid "Planned:  "

--- a/po/it_IT.po
+++ b/po/it_IT.po
@@ -1500,7 +1500,7 @@ msgstr "Non posso scrivere un file di piano senza un nome di progetto"
 #: lib/App/Sqitch/Role/TargetConfigCommand.pm:298
 #, perl-brace-format
 msgid "Cannot initialize because {file} already exists and is not a file"
-msgstr "Impossibile inizializzare poiché {file} eisste già e non è un file"
+msgstr "Impossibile inizializzare poiché {file} esiste già e non è un file"
 
 #: lib/App/Sqitch/Role/TargetConfigCommand.pm:309
 #, perl-brace-format
@@ -1515,7 +1515,7 @@ msgstr ""
 msgid ""
 "Cannot initialize because project \"{project}\" already initialized in {file}"
 msgstr ""
-"Impossibile inziializzare poiché il progetto \"{project}\" è già stato "
+"Impossibile inizializzare poiché il progetto \"{project}\" è già stato "
 "inizializzato in {file}"
 
 #: lib/App/Sqitch/Target.pm:76 lib/App/Sqitch/Target.pm:303

--- a/po/it_IT.po
+++ b/po/it_IT.po
@@ -1,0 +1,1469 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR "iovation Inc."
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: App-Sqitch 0.9996\n"
+"Report-Msgid-Bugs-To: david@justatheory.com\n"
+"POT-Creation-Date: 2017-10-04 13:34+0200\n"
+"PO-Revision-Date: 2017-10-04 14:02+0200\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.1\n"
+"Last-Translator: \n"
+"Language: it_IT\n"
+
+#: lib/App/Sqitch.pm:79
+msgid "Cannot find your name; run sqitch config --user user.name \"YOUR NAME\""
+msgstr ""
+"Impossibile trovare il tuo nome: esegui sqitch config --user user.name \"TUO "
+"NOME\""
+
+#: lib/App/Sqitch.pm:105
+msgid ""
+"Cannot infer your email address; run sqitch config --user user.email "
+"you@host.com"
+msgstr ""
+"Non riesco a risalire alla tua e-mail: esegui sqitch config --user user."
+"email tuaemail@host.com"
+
+#: lib/App/Sqitch.pm:321
+#, perl-brace-format
+msgid ""
+"  The \"{opt}\" option is deprecated;\n"
+"  Instead use \"--dir {dir}={val}\" if available."
+msgstr ""
+"L'opzione \"{opt}\" è deprecata;\n"
+"usa \"--dir {dir}={val}\" se disponibile"
+
+#: lib/App/Sqitch.pm:421
+msgid ""
+"Sqitch seems to be unattended and there is no default value for this question"
+msgstr ""
+"Sqitch sembra non presidiato e non ha un valore di default per il quesito"
+
+#: lib/App/Sqitch.pm:450
+msgid "Please answer \"y\" or \"n\"."
+msgstr "Rispondi \"y\" (si) o \"n\" (no)"
+
+#: lib/App/Sqitch.pm:453
+msgid "No valid answer after 3 attempts; aborting"
+msgstr "Nessuna risposta valida in 3 tentativi, aborto"
+
+#: lib/App/Sqitch.pm:463 lib/App/Sqitch.pm:470
+#, perl-brace-format
+msgid "Cannot exec {command}: {error}"
+msgstr "Non posso eseguire {command}: {error}"
+
+#: lib/App/Sqitch.pm:486
+#, perl-brace-format
+msgid "Error closing pipe to {command}: {error}"
+msgstr "Errore di chiusura pipe per {command}: {error}"
+
+#: lib/App/Sqitch.pm:490 lib/App/Sqitch/Engine/oracle.pm:751
+#, perl-brace-format
+msgid "{command} unexpectedly returned exit value {exitval}"
+msgstr "Il comando {command} ha restituito un exit value inatteso {exitval}"
+
+#: lib/App/Sqitch/Command.pm:109
+#, perl-brace-format
+msgid "\"{command}\" is not a valid command"
+msgstr "\"{command}\" non è un comando valido"
+
+#: lib/App/Sqitch/Command.pm:264
+#, perl-brace-format
+msgid "Unknown argument \"{arg}\""
+msgid_plural "Unknown arguments: {arg}"
+msgstr[0] "Argomento sconosciuto: \"{arg}\""
+msgstr[1] "Argomenti sconosciuti: {arg}"
+
+#: lib/App/Sqitch/Command.pm:276
+msgid "Cannot specify both --all and engine, target, or plan arugments"
+msgstr ""
+"Non si puo' specificare contemporaneamente --all e engine, target o plan."
+
+#: lib/App/Sqitch/Command/add.pm:102
+#, perl-brace-format
+msgid "Template {template} does not exist"
+msgstr "Il template {template} non esiste"
+
+#: lib/App/Sqitch/Command/add.pm:107
+#, perl-brace-format
+msgid "Template {template} is not a file"
+msgstr "Il tempalte {template} non è un file"
+
+#: lib/App/Sqitch/Command/add.pm:153
+#, perl-brace-format
+msgid "Cannot find {script} template"
+msgstr "Non trovo il template {script}"
+
+#: lib/App/Sqitch/Command/add.pm:218
+#, perl-brace-format
+msgid "Option --{opt} has been deprecated; use \"--{with} {val}\" instead"
+msgstr "L'opzione --{opt} è deprecata, usa \"--{with} {val}\" al suo posto"
+
+#: lib/App/Sqitch/Command/add.pm:236
+#, perl-brace-format
+msgid "Option --{opt} has been deprecated; use \"--use {key}={val}\" instead"
+msgstr "L'opzione --{opt} è deprecata, usa \"--use {key}={val}\" al suo posto"
+
+#: lib/App/Sqitch/Command/add.pm:265
+#, perl-brace-format
+msgid "Directory \"{dir}\" does not exist"
+msgstr "La directory {dir} non esiste"
+
+#: lib/App/Sqitch/Command/add.pm:270
+#, perl-brace-format
+msgid "\"{dir}\" is not a directory"
+msgstr "\"{dir}\" non è una directory"
+
+#: lib/App/Sqitch/Command/add.pm:322
+#, perl-brace-format
+msgid ""
+"Name \"{name}\" identifies a target; use \"--change {name}\" to use it for "
+"the change name"
+msgstr ""
+"Il nome \"{name}\" identifica un target, usa \"--change {name}\" per "
+"effettuare il cambio di nome"
+
+#: lib/App/Sqitch/Command/add.pm:370
+msgid "add"
+msgstr "aggiungi"
+
+#: lib/App/Sqitch/Command/add.pm:388
+#, perl-brace-format
+msgid "Added \"{change}\" to {file}"
+msgstr "\"{change}\" aggiunta al file {file}"
+
+#: lib/App/Sqitch/Command/add.pm:407
+#, perl-brace-format
+msgid "Skipped {file}: already exists"
+msgstr "Salto {file}: esistente"
+
+#: lib/App/Sqitch/Command/add.pm:418 lib/App/Sqitch/Command/bundle.pm:141
+#: lib/App/Sqitch/Role/TargetConfigCommand.pm:261
+#, perl-brace-format
+msgid "Error creating {path}: {error}"
+msgstr "Errore durante la creazione di {path}: {error}"
+
+#: lib/App/Sqitch/Command/add.pm:435 lib/App/Sqitch/Command/add.pm:465
+#: lib/App/Sqitch/Plan.pm:135 lib/App/Sqitch/Plan.pm:588
+#: lib/App/Sqitch/Plan.pm:969 lib/App/Sqitch/Plan/Line.pm:107
+#: lib/App/Sqitch/Role/TargetConfigCommand.pm:325
+#, perl-brace-format
+msgid "Cannot open {file}: {error}"
+msgstr "Non posso aprire {file}: {error}"
+
+#: lib/App/Sqitch/Command/add.pm:443
+#, perl-brace-format
+msgid "Error executing {template}: {error}"
+msgstr "Errore nell'esecuzione di {template}: {error}"
+
+#: lib/App/Sqitch/Command/add.pm:455
+#: lib/App/Sqitch/Role/TargetConfigCommand.pm:336
+#, perl-brace-format
+msgid "Error closing {file}: {error}"
+msgstr "Errore nella chiusura di {file}: {error}"
+
+#: lib/App/Sqitch/Command/add.pm:459 lib/App/Sqitch/Command/bundle.pm:134
+#: lib/App/Sqitch/Command/init.pm:195
+#: lib/App/Sqitch/Role/TargetConfigCommand.pm:255
+#: lib/App/Sqitch/Role/TargetConfigCommand.pm:341
+#, perl-brace-format
+msgid "Created {file}"
+msgstr "{file} creato"
+
+#: lib/App/Sqitch/Command/bundle.pm:99
+msgid ""
+"Use of --to or --from to bundle multiple targets is not recommended.\n"
+"Pass them as arguments after each target argument, instead."
+msgstr ""
+"L'uso di --to o --from per creare un bundle con piu' target è sconsigliato.\n"
+"Passali come argomenti dopo ogni target."
+
+#: lib/App/Sqitch/Command/bundle.pm:106
+msgid "Cannot specify both --from or --to and change arguments"
+msgstr ""
+"Non puoi usare contemporanemanete --from o --to e cambiare gli argomenti"
+
+#: lib/App/Sqitch/Command/bundle.pm:111
+#, perl-brace-format
+msgid "Bundling into {dir}"
+msgstr "Creazione bundle in {dir}"
+
+#: lib/App/Sqitch/Command/bundle.pm:152
+#, perl-brace-format
+msgid "Cannot copy {file}: does not exist"
+msgstr "Non posso copiare {file}: non esiste"
+
+#: lib/App/Sqitch/Command/bundle.pm:165
+#, perl-brace-format
+msgid "Copying {source} -> {dest}"
+msgstr "Copio {source} -> {dest}"
+
+#: lib/App/Sqitch/Command/bundle.pm:172
+#, perl-brace-format
+msgid "Cannot copy \"{source}\" to \"{dest}\": {error}"
+msgstr "Non posso copiare \"{source}\" in \"{dest}\": {error}"
+
+#: lib/App/Sqitch/Command/bundle.pm:182
+msgid "Writing config"
+msgstr "Salvo configurazione"
+
+#: lib/App/Sqitch/Command/bundle.pm:193
+msgid "Writing plan"
+msgstr "Salvo piano esecuzione (plan)"
+
+#: lib/App/Sqitch/Command/bundle.pm:202
+#, perl-brace-format
+msgid "Writing plan from {from} to {to}"
+msgstr "Salvo piano da {from} a {to}"
+
+#: lib/App/Sqitch/Command/bundle.pm:222 lib/App/Sqitch/Command/bundle.pm:229
+#: lib/App/Sqitch/Plan.pm:941 lib/App/Sqitch/Plan.pm:950
+#, perl-brace-format
+msgid "Cannot find change {change}"
+msgstr "Non trovo la modifica {change}"
+
+#: lib/App/Sqitch/Command/bundle.pm:233
+msgid "Writing scripts"
+msgstr "Salvo gli script"
+
+#: lib/App/Sqitch/Command/checkout.pm:46 lib/App/Sqitch/Command/deploy.pm:111
+#: lib/App/Sqitch/Command/log.pm:203 lib/App/Sqitch/Command/rebase.pm:72
+#: lib/App/Sqitch/Command/revert.pm:117 lib/App/Sqitch/Command/status.pm:107
+#: lib/App/Sqitch/Command/verify.pm:94
+#, perl-brace-format
+msgid "Too many targets specified; connecting to {target}"
+msgstr "Troppo pochi target specificati: collegamento a {target}"
+
+#: lib/App/Sqitch/Command/checkout.pm:63
+#, perl-brace-format
+msgid "Already on branch {branch}"
+msgstr "Già nel ramo {branch}"
+
+#: lib/App/Sqitch/Command/checkout.pm:90
+#, perl-brace-format
+msgid "Branch {branch} has no changes in common with current branch {current}"
+msgstr ""
+"Il ramo {branch} non ha modifiche in comune con il ramo corrente {current}"
+
+#: lib/App/Sqitch/Command/checkout.pm:96
+#, perl-brace-format
+msgid "Last change before the branches diverged: {last_change}"
+msgstr "Ultima modifica prima della divergenza dei rami: {last_change}"
+
+#: lib/App/Sqitch/Command/config.pm:129
+#, perl-brace-format
+msgid "Unknown config action: {action}"
+msgstr "Azione di configurazione sconosciuta: {action}"
+
+#: lib/App/Sqitch/Command/config.pm:149
+#, perl-brace-format
+msgid "More then one value for the key \"{key}\""
+msgstr "Piu' di un valore per la chiave \"{key}\""
+
+#: lib/App/Sqitch/Command/config.pm:261
+msgid "Cannot overwrite multiple values with a single value"
+msgstr "Non posso sovrascrivere piu' valori con un singolo valore"
+
+#: lib/App/Sqitch/Command/config.pm:291
+msgid "Cannot unset key with multiple values"
+msgstr "Non posso invalidare una chiave con multipli valori"
+
+#: lib/App/Sqitch/Command/config.pm:344 lib/App/Sqitch/Command/config.pm:361
+msgid "No such section!"
+msgstr "Non esiste la sezione!"
+
+#: lib/App/Sqitch/Command/deploy.pm:85 lib/App/Sqitch/Command/revert.pm:80
+msgid ""
+"The --to-target and --target option has been deprecated; use --to-change "
+"instead."
+msgstr ""
+"Le opzioni --to-target e --target sono deprecate: usa --to-change al loro "
+"posto."
+
+#: lib/App/Sqitch/Command/deploy.pm:118
+#, perl-brace-format
+msgid "Too many changes specified; deploying to \"{change}\""
+msgstr "Troppi cambiamenti specificati: deploy per \"{change}\""
+
+#: lib/App/Sqitch/Command/engine.pm:34 lib/App/Sqitch/Command/engine.pm:184
+#: lib/App/Sqitch/Command/engine.pm:261
+#: lib/App/Sqitch/Role/TargetConfigCommand.pm:112
+#, perl-brace-format
+msgid "Unknown engine \"{engine}\""
+msgstr "Engine sconosciuto: \"{engine}\""
+
+#: lib/App/Sqitch/Command/engine.pm:50 lib/App/Sqitch/Command/target.pm:43
+#, perl-brace-format
+msgid "Unknown action \"{action}\""
+msgstr "Azione sconosciuta: \"{action}\""
+
+#: lib/App/Sqitch/Command/engine.pm:80
+#, perl-brace-format
+msgid "Cannot assign URI using engine \"{new}\" to engine \"{old}\""
+msgstr ""
+"Non posso assegnare nessun URI usando l'engine da \"{new}\" a \"{old}\""
+
+#: lib/App/Sqitch/Command/engine.pm:90 lib/App/Sqitch/Command/engine.pm:208
+#: lib/App/Sqitch/Command/target.pm:140 lib/App/Sqitch/Command/target.pm:240
+#, perl-brace-format
+msgid "Unknown target \"{target}\""
+msgstr "Target sconosciuto: \"{target}\""
+
+#: lib/App/Sqitch/Command/engine.pm:104
+#, perl-brace-format
+msgid "Engine \"{engine}\" already exists"
+msgstr "L'engine \"{engine}\" esiste già"
+
+#: lib/App/Sqitch/Command/engine.pm:143
+#, perl-brace-format
+msgid "Missing Engine \"{engine}\"; use \"{command}\" to add it"
+msgstr "Engine mancante:\"{engine}\"; usa \"{command}\" per aggiungerlo"
+
+#: lib/App/Sqitch/Command/engine.pm:152
+msgid "Cannot unset an engine target"
+msgstr "Non posso invalidare un target di tipo engine"
+
+#: lib/App/Sqitch/Command/engine.pm:174 lib/App/Sqitch/Command/target.pm:131
+#, perl-brace-format
+msgid ""
+"  The \"{old}\" action is deprecated;\n"
+"  Instead use \"{new}\"."
+msgstr ""
+"  L'azione \"{old}\" è deprecata;\n"
+"  usa \"{new}\" al suo posto."
+
+#: lib/App/Sqitch/Command/engine.pm:276
+msgid "Target"
+msgstr ""
+
+#: lib/App/Sqitch/Command/engine.pm:277 lib/App/Sqitch/Command/target.pm:255
+msgid "Registry"
+msgstr ""
+
+#: lib/App/Sqitch/Command/engine.pm:278 lib/App/Sqitch/Command/target.pm:256
+msgid "Client"
+msgstr ""
+
+#: lib/App/Sqitch/Command/engine.pm:279 lib/App/Sqitch/Command/target.pm:257
+msgid "Top Directory"
+msgstr ""
+
+#: lib/App/Sqitch/Command/engine.pm:280 lib/App/Sqitch/Command/target.pm:258
+msgid "Plan File"
+msgstr ""
+
+#: lib/App/Sqitch/Command/engine.pm:281 lib/App/Sqitch/Command/target.pm:259
+msgid "Extension"
+msgstr ""
+
+#: lib/App/Sqitch/Command/engine.pm:282 lib/App/Sqitch/Command/target.pm:260
+#: lib/App/Sqitch/ItemFormatter.pm:62
+msgid "Revert"
+msgstr ""
+
+#: lib/App/Sqitch/Command/engine.pm:283 lib/App/Sqitch/Command/target.pm:261
+#: lib/App/Sqitch/ItemFormatter.pm:61
+msgid "Deploy"
+msgstr ""
+
+#: lib/App/Sqitch/Command/engine.pm:284 lib/App/Sqitch/Command/target.pm:262
+msgid "Verify"
+msgstr ""
+
+#: lib/App/Sqitch/Command/engine.pm:285 lib/App/Sqitch/Command/target.pm:263
+msgid "Reworked"
+msgstr ""
+
+#: lib/App/Sqitch/Command/engine.pm:292 lib/App/Sqitch/Command/target.pm:270
+msgid "Script Directories"
+msgstr ""
+
+#: lib/App/Sqitch/Command/engine.pm:293 lib/App/Sqitch/Command/target.pm:271
+msgid "Reworked Script Directories"
+msgstr ""
+
+#: lib/App/Sqitch/Command/engine.pm:334
+#, perl-brace-format
+msgid "Loading {file}"
+msgstr "Caricamento di {file}"
+
+#: lib/App/Sqitch/Command/engine.pm:347
+#, perl-brace-format
+msgid ""
+"Deprecated {section} found in {file}; to remove it, run\n"
+"    {sqitch} config --file {file} --remove-section {section}"
+msgstr ""
+"Sezione {section} nel file {file} è deprecata; per rimuoverla esegui\n"
+"    {sqitch} config --file {file} --remove-section {section}"
+
+#: lib/App/Sqitch/Command/engine.pm:359
+msgid "  - No engines to update"
+msgstr " - Nessun engine da aggiornare"
+
+#: lib/App/Sqitch/Command/engine.pm:366
+#, perl-brace-format
+msgid "Cannot update {file}. Please make it writable"
+msgstr "Impossibile aggiornare il file {file}. Rendilo scrivibile"
+
+#: lib/App/Sqitch/Command/engine.pm:422
+#, perl-brace-format
+msgid ""
+"Migrated {old} to {new}; To remove {old}, run\n"
+"    {sqitch} config --file {file} --remove-section {old}"
+msgstr ""
+"MIgraziene da {old} a {new} completata. Per rimuovere {old} esegui\n"
+"    {sqitch} config --file {file} --remove-section {old}"
+
+#: lib/App/Sqitch/Command/help.pm:46
+#, perl-brace-format
+msgid "No manual entry for {command}"
+msgstr "Non trovo {command} nel manuale"
+
+#: lib/App/Sqitch/Command/init.pm:50 lib/App/Sqitch/Plan.pm:238
+#, perl-brace-format
+msgid ""
+"invalid project name \"{project}\": project names must not begin with "
+"punctuation, contain \"@\", \":\", \"#\", or blanks, or end in punctuation "
+"or digits following punctuation"
+msgstr ""
+"Il nome di progetto \"{project}\" non è valido: I nomi di progetto non "
+"possono iniziare con punteggiarura, contenere \"@\", \":\", \"#\", o spazi "
+"bianchi e non possono terminare con simboli di punteggiatura o numeri dopo "
+"dopo la punteggiatura."
+
+#: lib/App/Sqitch/Command/log.pm:174
+#, perl-brace-format
+msgid "Unknown log format \"{format}\""
+msgstr "Formato di log sconosciuto: \"{format}\""
+
+#: lib/App/Sqitch/Command/log.pm:213 lib/App/Sqitch/Command/status.pm:128
+#, perl-brace-format
+msgid "Database {db} has not been initialized for Sqitch"
+msgstr "Il database {db} non è stato inizializzato per l'uso con Sqitch"
+
+#: lib/App/Sqitch/Command/log.pm:224
+#, perl-brace-format
+msgid "No events logged for {db}"
+msgstr "Nessun logger di eventi per {db}"
+
+#: lib/App/Sqitch/Command/log.pm:243 lib/App/Sqitch/Command/status.pm:116
+#, perl-brace-format
+msgid "On database {db}"
+msgstr ""
+
+#: lib/App/Sqitch/Command/plan.pm:163
+#, perl-brace-format
+msgid "Unknown plan format \"{format}\""
+msgstr ""
+
+#: lib/App/Sqitch/Command/plan.pm:192 lib/App/Sqitch/Command/upgrade.pm:39
+#, perl-brace-format
+msgid "Too many targets specified; using {target}"
+msgstr ""
+
+#: lib/App/Sqitch/Command/plan.pm:202
+#, perl-brace-format
+msgid "No changes in {file}"
+msgstr ""
+
+#: lib/App/Sqitch/Command/plan.pm:220
+#, perl-brace-format
+msgid "Project: {project}"
+msgstr ""
+
+#: lib/App/Sqitch/Command/plan.pm:221
+#, perl-brace-format
+msgid "File:    {file}"
+msgstr ""
+
+#: lib/App/Sqitch/Command/rebase.pm:51 lib/App/Sqitch/Command/verify.pm:65
+#, perl-brace-format
+msgid "Option --{old} has been deprecated; use --{new} instead"
+msgstr ""
+
+#: lib/App/Sqitch/Command/rebase.pm:80
+#, perl-brace-format
+msgid "Too many changes specified; rebasing onto \"{onto}\" up to \"{upto}\""
+msgstr ""
+
+#: lib/App/Sqitch/Command/revert.pm:124
+#, perl-brace-format
+msgid "Too many changes specified; reverting to \"{change}\""
+msgstr ""
+
+#: lib/App/Sqitch/Command/rework.pm:153
+msgid "rework"
+msgstr ""
+
+#: lib/App/Sqitch/Command/rework.pm:171
+#, perl-brace-format
+msgid "Added \"{change}\" to {file}."
+msgstr ""
+
+#: lib/App/Sqitch/Command/rework.pm:179
+msgid "Modify this file as appropriate:"
+msgid_plural "Modify these files as appropriate:"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/App/Sqitch/Command/rework.pm:199
+#, perl-brace-format
+msgid "Skipped {dest}: {src} does not exist"
+msgstr ""
+
+#: lib/App/Sqitch/Command/rework.pm:208
+#, perl-brace-format
+msgid "Cannot copy {src} to {dest}: {error}"
+msgstr ""
+
+#: lib/App/Sqitch/Command/rework.pm:215
+#, perl-brace-format
+msgid "Copied {src} to {dest}"
+msgstr ""
+
+#: lib/App/Sqitch/Command/show.pm:70 lib/App/Sqitch/Plan/ChangeList.pm:106
+#, perl-brace-format
+msgid "Unknown tag \"{tag}\""
+msgstr ""
+
+#: lib/App/Sqitch/Command/show.pm:78
+#, perl-brace-format
+msgid "Unknown object type \"{type}"
+msgstr ""
+
+#: lib/App/Sqitch/Command/show.pm:86
+#, perl-brace-format
+msgid "Unknown change \"{change}\""
+msgstr ""
+
+#: lib/App/Sqitch/Command/show.pm:101
+#, perl-brace-format
+msgid "File \"{path}\" does not exist"
+msgstr ""
+
+#: lib/App/Sqitch/Command/show.pm:103
+#, perl-brace-format
+msgid "\"{path}\" is not a file"
+msgstr ""
+
+#: lib/App/Sqitch/Command/status.pm:74
+msgid "Database not initialized for Sqitch"
+msgstr ""
+
+#: lib/App/Sqitch/Command/status.pm:77
+msgid "No projects registered"
+msgstr ""
+
+#: lib/App/Sqitch/Command/status.pm:79
+#, perl-brace-format
+msgid "Use --project to select which project to query: {projects}"
+msgstr ""
+
+#: lib/App/Sqitch/Command/status.pm:80 lib/App/Sqitch/Command/status.pm:203
+#: lib/App/Sqitch/Role/TargetConfigCommand.pm:95
+msgid ", "
+msgstr ""
+
+#: lib/App/Sqitch/Command/status.pm:135 lib/App/Sqitch/Engine.pm:346
+msgid "No changes deployed"
+msgstr ""
+
+#: lib/App/Sqitch/Command/status.pm:153
+#, perl-brace-format
+msgid "Status unknown. Use --plan-file to assess \"{project}\" status"
+msgstr ""
+
+#: lib/App/Sqitch/Command/status.pm:187
+#, perl-brace-format
+msgid "Project:  {project}"
+msgstr ""
+
+#: lib/App/Sqitch/Command/status.pm:191
+#, perl-brace-format
+msgid "Change:   {change_id}"
+msgstr ""
+
+#: lib/App/Sqitch/Command/status.pm:195
+#, perl-brace-format
+msgid "Name:     {change}"
+msgstr ""
+
+#: lib/App/Sqitch/Command/status.pm:200
+#, perl-brace-format
+msgid "Tag:      {tags}"
+msgid_plural "Tags:     {tags}"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/App/Sqitch/Command/status.pm:208
+#, perl-brace-format
+msgid "Deployed: {date}"
+msgstr ""
+
+#: lib/App/Sqitch/Command/status.pm:214
+#, perl-brace-format
+msgid "By:       {name} <{email}>"
+msgstr ""
+
+#: lib/App/Sqitch/Command/status.pm:237
+msgid "Change:"
+msgid_plural "Changes:"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/App/Sqitch/Command/status.pm:266
+msgid "Tags: None."
+msgstr ""
+
+#: lib/App/Sqitch/Command/status.pm:270
+msgid "Tag:"
+msgid_plural "Tags:"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/App/Sqitch/Command/status.pm:296
+#, perl-brace-format
+msgid "Cannot find this change in {file}"
+msgstr ""
+
+#: lib/App/Sqitch/Command/status.pm:299
+msgid "Make sure you are connected to the proper database for this project."
+msgstr ""
+
+#: lib/App/Sqitch/Command/status.pm:305 lib/App/Sqitch/Engine.pm:179
+msgid "Nothing to deploy (up-to-date)"
+msgstr ""
+
+#: lib/App/Sqitch/Command/status.pm:308 lib/App/Sqitch/Engine.pm:495
+msgid "Undeployed change:"
+msgid_plural "Undeployed changes:"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/App/Sqitch/Command/tag.pm:80
+msgid "tag"
+msgstr ""
+
+#: lib/App/Sqitch/Command/tag.pm:88
+#, perl-brace-format
+msgid "Tagged \"{change}\" with {tag} in {file}"
+msgstr ""
+
+#: lib/App/Sqitch/Command/tag.pm:100
+#, perl-brace-format
+msgid ""
+"Name \"{name}\" identifies a target; use \"--tag {name}\" to use it for the "
+"tag name"
+msgstr ""
+
+#: lib/App/Sqitch/Command/target.pm:71
+#, perl-brace-format
+msgid "Target \"{target}\" already exists"
+msgstr ""
+
+#: lib/App/Sqitch/Command/target.pm:106
+#, perl-brace-format
+msgid "Missing Target \"{target}\"; use \"{command}\" to add it"
+msgstr ""
+
+#: lib/App/Sqitch/Command/target.pm:198 lib/App/Sqitch/Command/target.pm:211
+#, perl-brace-format
+msgid "Cannot rename target \"{target}\" because it's referenced by: {engines}"
+msgstr ""
+
+#: lib/App/Sqitch/Command/target.pm:254
+msgid "URI"
+msgstr ""
+
+#: lib/App/Sqitch/Command/upgrade.pm:48
+#, perl-brace-format
+msgid "Upgrading registry {registry} to version {version}"
+msgstr ""
+
+#: lib/App/Sqitch/Command/upgrade.pm:55
+#, perl-brace-format
+msgid "Registry {registry} is up-to-date at version {version}"
+msgstr ""
+
+#: lib/App/Sqitch/Command/verify.pm:102
+#, perl-brace-format
+msgid "Too many changes specified; verifying from \"{from}\" to \"{to}\""
+msgstr ""
+
+#: lib/App/Sqitch/Config.pm:26
+msgid "Could not determine home directory"
+msgstr ""
+
+#: lib/App/Sqitch/DateTime.pm:32 lib/App/Sqitch/DateTime.pm:70
+#, perl-brace-format
+msgid "Unknown date format \"{format}\""
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:112 lib/App/Sqitch/Engine.pm:124
+#: lib/App/Sqitch/Target.pm:252
+msgid "No engine specified; use --engine or set core.engine"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:146
+#, perl-brace-format
+msgid "{driver} required to manage {engine}"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:159
+msgid "Nothing to deploy (empty plan)"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:163 lib/App/Sqitch/Engine.pm:256
+#: lib/App/Sqitch/Plan.pm:735 lib/App/Sqitch/Plan/ChangeList.pm:155
+#, perl-brace-format
+msgid "Unknown change: \"{change}\""
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:170
+#, perl-brace-format
+msgid "Nothing to deploy (already at \"{change}\")"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:188
+#, perl-brace-format
+msgid "Adding registry tables to {destination}"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:197
+msgid "Cannot deploy to an earlier change; use \"revert\" instead"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:205
+#, perl-brace-format
+msgid "Deploying changes through {change} to {destination}"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:209
+#, perl-brace-format
+msgid "Deploying changes to {destination}"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:222
+#, perl-brace-format
+msgid "Unknown deployment mode: \"{mode}\""
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:250
+#, perl-brace-format
+msgid "Change not deployed: \"{change}\""
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:266
+#, perl-brace-format
+msgid "No changes deployed since: \"{change}\""
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:274
+#, perl-brace-format
+msgid "Reverting changes to {change} from {destination}"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:281 lib/App/Sqitch/Engine.pm:305
+msgid "Nothing reverted"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:284
+#, perl-brace-format
+msgid "Revert changes to {change} from {destination}?"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:293
+msgid "Nothing to revert (nothing deployed)"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:299
+#, perl-brace-format
+msgid "Reverting all changes from {destination}"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:308
+#, perl-brace-format
+msgid "Revert all changes from {destination}?"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:339
+#, perl-brace-format
+msgid "Verifying {destination}"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:347
+msgid "Nothing to verify (no planned or deployed changes)"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:357
+msgid "There are deployed changes, but none planned!"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:377
+msgid "Verify Summary Report"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:380
+#, perl-brace-format
+msgid "Changes: {number}"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:381
+#, perl-brace-format
+msgid "Errors:  {number}"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:382
+msgid "Verify failed"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:387
+msgid "Verify successful"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:400
+#, perl-brace-format
+msgid "Change \"{change}\" has not been deployed"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:403
+#, perl-brace-format
+msgid "Cannot find \"{change}\" in the database or the plan"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:410
+#, perl-brace-format
+msgid "Change \"{change}\" is deployed, but not planned"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:454
+msgid "Out of order"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:460
+msgid "Not present in the plan"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:471 lib/App/Sqitch/Engine.pm:483
+#: lib/App/Sqitch/Engine.pm:963 lib/App/Sqitch/Engine.pm:993
+msgid "not ok"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:471 lib/App/Sqitch/Engine.pm:941
+#: lib/App/Sqitch/Engine.pm:983
+msgid "ok"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:485
+msgid "Not deployed"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:517
+#, perl-brace-format
+msgid "Verify script \"{script}\" failed."
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:526
+#, perl-brace-format
+msgid "Verify script {file} does not exist"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:567
+#, perl-brace-format
+msgid "Conflicts with previously deployed change: {changes}"
+msgid_plural "Conflicts with previously deployed changes: {changes}"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/App/Sqitch/Engine.pm:574
+#, perl-brace-format
+msgid "Missing required change: {changes}"
+msgid_plural "Missing required changes: {changes}"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/App/Sqitch/Engine.pm:586
+#, perl-brace-format
+msgid "Change \"{changes}\" has already been deployed"
+msgid_plural "Changes have already been deployed: {changes}"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/App/Sqitch/Engine.pm:609
+#, perl-brace-format
+msgid "Change \"{change}\" required by currently deployed change: {changes}"
+msgid_plural ""
+"Change \"{change}\" required by currently deployed changes: {changes}"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/App/Sqitch/Engine.pm:632
+#, perl-brace-format
+msgid "Invalid dependency: {dependency}"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:766 lib/App/Sqitch/Plan/ChangeList.pm:122
+#, perl-brace-format
+msgid ""
+"Change \"{change}\" is ambiguous. Please specify a tag-qualified change:"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:781
+msgid "Change Lookup Failed"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:802
+#, perl-brace-format
+msgid "Reverting to {change}"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:803
+msgid "Reverting all changes"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:811
+msgid "The schema will need to be manually repaired"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:815 lib/App/Sqitch/Engine.pm:957
+msgid "Deploy failed"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:872
+#, perl-brace-format
+msgid "Cannot find change {id} ({change}) in {file}"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:913
+#, perl-brace-format
+msgid "Updating legacy change and tag IDs in {destination}"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:1026
+#, perl-brace-format
+msgid "No registry found in {destination}. Have you ever deployed?"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:1031
+#, perl-brace-format
+msgid ""
+"Registry version is {old} but {new} is the latest known. Please upgrade "
+"Sqitch"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:1037
+#, perl-brace-format
+msgid ""
+"Registry is at version {old} but latest is {new}. Please run the \"upgrade\" "
+"conmand"
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:1052
+#, perl-brace-format
+msgid ""
+"Registry version is {old} but {new} is the latest known. Please upgrade "
+"Sqitch."
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:1067
+#, perl-brace-format
+msgid "Cannot upgrade to {version}: Cannot find upgrade script \"{file}\""
+msgstr ""
+
+#: lib/App/Sqitch/Engine.pm:1076
+#, perl-brace-format
+msgid "From {old} to {new}"
+msgstr ""
+
+#: lib/App/Sqitch/Engine/firebird.pm:204 lib/App/Sqitch/Engine/mysql.pm:248
+#: lib/App/Sqitch/Engine/sqlite.pm:158
+#, perl-brace-format
+msgid "Sqitch database {database} already initialized"
+msgstr ""
+
+#: lib/App/Sqitch/Engine/firebird.pm:223
+#, perl-brace-format
+msgid "Cannot create database {database}: {error}"
+msgstr ""
+
+#: lib/App/Sqitch/Engine/firebird.pm:237 lib/App/Sqitch/Engine/sqlite.pm:127
+#, perl-brace-format
+msgid "Database name missing in URI {uri}"
+msgstr ""
+
+#: lib/App/Sqitch/Engine/firebird.pm:880 lib/App/Sqitch/Engine/firebird.pm:897
+#: lib/App/Sqitch/Engine/firebird.pm:908
+#, perl-brace-format
+msgid "Cannot dup STDERR: {error}"
+msgstr ""
+
+#: lib/App/Sqitch/Engine/firebird.pm:884
+#, perl-brace-format
+msgid "Cannot reirect STDERR: {error}"
+msgstr ""
+
+#: lib/App/Sqitch/Engine/firebird.pm:911
+msgid ""
+"Unable to locate Firebird ISQL; set \"engine.firebird.client\" via sqitch "
+"config"
+msgstr ""
+
+#: lib/App/Sqitch/Engine/mysql.pm:110
+#, perl-brace-format
+msgid ""
+"Sqitch requires {rdbms} {want_version} or higher; this is {have_version}"
+msgstr ""
+
+#: lib/App/Sqitch/Engine/mysql.pm:142
+#, perl-brace-format
+msgid "Database name missing in URI \"{uri}\""
+msgstr ""
+
+#: lib/App/Sqitch/Engine/oracle.pm:443
+msgid "Sqitch already initialized"
+msgstr ""
+
+#: lib/App/Sqitch/Engine/oracle.pm:573
+#, perl-brace-format
+msgid "Cannot remove {file}: {error}"
+msgstr ""
+
+#: lib/App/Sqitch/Engine/oracle.pm:582
+#, perl-brace-format
+msgid "Cannot copy {file} to {alias}: {error}"
+msgstr ""
+
+#: lib/App/Sqitch/Engine/oracle.pm:591
+#, perl-brace-format
+msgid "Cannot symlink {file} to {alias}: {error}"
+msgstr ""
+
+#: lib/App/Sqitch/Engine/pg.pm:169 lib/App/Sqitch/Engine/vertica.pm:154
+#, perl-brace-format
+msgid "Sqitch schema \"{schema}\" already exists"
+msgstr ""
+
+#: lib/App/Sqitch/Engine/sqlite.pm:98
+#, perl-brace-format
+msgid ""
+"Sqitch requires SQLite 3.7.11 or later; DBD::SQLite was built with {version}"
+msgstr ""
+
+#: lib/App/Sqitch/Engine/sqlite.pm:121
+#, perl-brace-format
+msgid "Sqitch requires SQLite 3.3.9 or later; {client} is {version}"
+msgstr ""
+
+#: lib/App/Sqitch/ItemFormatter.pm:63
+msgid "Fail"
+msgstr ""
+
+#: lib/App/Sqitch/ItemFormatter.pm:68
+msgid "deploy"
+msgstr ""
+
+#: lib/App/Sqitch/ItemFormatter.pm:69
+msgid "revert"
+msgstr ""
+
+#: lib/App/Sqitch/ItemFormatter.pm:70
+msgid "fail"
+msgstr ""
+
+#: lib/App/Sqitch/ItemFormatter.pm:75
+msgid "Event:    "
+msgstr ""
+
+#: lib/App/Sqitch/ItemFormatter.pm:76
+msgid "Change:   "
+msgstr ""
+
+#: lib/App/Sqitch/ItemFormatter.pm:77
+msgid "Committer:"
+msgstr ""
+
+#: lib/App/Sqitch/ItemFormatter.pm:78
+msgid "Planner:  "
+msgstr ""
+
+#: lib/App/Sqitch/ItemFormatter.pm:79
+msgid "By:       "
+msgstr ""
+
+#: lib/App/Sqitch/ItemFormatter.pm:80
+msgid "Date:     "
+msgstr ""
+
+#: lib/App/Sqitch/ItemFormatter.pm:81
+msgid "Committed:"
+msgstr ""
+
+#: lib/App/Sqitch/ItemFormatter.pm:82
+msgid "Planned:  "
+msgstr ""
+
+#: lib/App/Sqitch/ItemFormatter.pm:83
+msgid "Name:     "
+msgstr ""
+
+#: lib/App/Sqitch/ItemFormatter.pm:84
+msgid "Project:  "
+msgstr ""
+
+#: lib/App/Sqitch/ItemFormatter.pm:85
+msgid "Email:    "
+msgstr ""
+
+#: lib/App/Sqitch/ItemFormatter.pm:86 lib/App/Sqitch/ItemFormatter.pm:176
+msgid "Requires: "
+msgstr ""
+
+#: lib/App/Sqitch/ItemFormatter.pm:87 lib/App/Sqitch/ItemFormatter.pm:187
+msgid "Conflicts:"
+msgstr ""
+
+#: lib/App/Sqitch/ItemFormatter.pm:89
+msgid "No label passed to the _ format"
+msgstr ""
+
+#: lib/App/Sqitch/ItemFormatter.pm:93
+#, perl-brace-format
+msgid "Unknown label \"{label}\" passed to the _ format"
+msgstr ""
+
+#: lib/App/Sqitch/ItemFormatter.pm:150
+#, perl-brace-format
+msgid "{color} is not a valid ANSI color"
+msgstr ""
+
+#: lib/App/Sqitch/ItemFormatter.pm:193
+#, perl-brace-format
+msgid "{attr} is not a valid change attribute"
+msgstr ""
+
+#: lib/App/Sqitch/ItemFormatter.pm:216
+#, perl-brace-format
+msgid "Unknown format code \"{code}\""
+msgstr ""
+
+#: lib/App/Sqitch/Plan.pm:130
+#, perl-brace-format
+msgid "Plan file {file} does not exist"
+msgstr ""
+
+#: lib/App/Sqitch/Plan.pm:132
+#, perl-brace-format
+msgid "Plan file {file} is not a regular file"
+msgstr ""
+
+#: lib/App/Sqitch/Plan.pm:183
+#, perl-brace-format
+msgid "Syntax error in {file} at line {lineno}: {error}"
+msgstr ""
+
+#: lib/App/Sqitch/Plan.pm:207
+msgid "Invalid pragma; a blank line must come between pragmas and changes"
+msgstr ""
+
+#: lib/App/Sqitch/Plan.pm:264
+#, perl-format, perl-brace-format
+msgid "Missing %project pragma in {file}"
+msgstr ""
+
+#: lib/App/Sqitch/Plan.pm:319
+msgid ""
+"Invalid name; names must not begin with punctuation, contain \"@\", \":\", "
+"\"#\", or blanks, or end in punctuation or digits following punctuation"
+msgstr ""
+
+#: lib/App/Sqitch/Plan.pm:324
+msgid "Missing timestamp and planner name and email"
+msgstr ""
+
+#: lib/App/Sqitch/Plan.pm:326
+msgid "Missing timestamp"
+msgstr ""
+
+#: lib/App/Sqitch/Plan.pm:328
+msgid "Missing planner name and email"
+msgstr ""
+
+#: lib/App/Sqitch/Plan.pm:333 lib/App/Sqitch/Plan.pm:894
+#, perl-brace-format
+msgid "\"{name}\" is a reserved name"
+msgstr ""
+
+#: lib/App/Sqitch/Plan.pm:339 lib/App/Sqitch/Plan.pm:898
+#, perl-brace-format
+msgid "\"{name}\" is invalid because it could be confused with a SHA1 ID"
+msgstr ""
+
+#: lib/App/Sqitch/Plan.pm:359
+#, perl-brace-format
+msgid "Tag \"{tag}\" declared without a preceding change"
+msgstr ""
+
+#: lib/App/Sqitch/Plan.pm:368
+#, perl-brace-format
+msgid "Tag \"{tag}\" duplicates earlier declaration on line {line}"
+msgstr ""
+
+#: lib/App/Sqitch/Plan.pm:376
+msgid "Tags may not specify dependencies"
+msgstr ""
+
+#: lib/App/Sqitch/Plan.pm:405
+#, perl-brace-format
+msgid "Change \"{change}\" duplicates earlier declaration on line {line}"
+msgstr ""
+
+#: lib/App/Sqitch/Plan.pm:418 lib/App/Sqitch/Plan.pm:766
+#: lib/App/Sqitch/Plan.pm:778
+#, perl-brace-format
+msgid "\"{dep}\" is not a valid dependency specification"
+msgstr ""
+
+#: lib/App/Sqitch/Plan.pm:536
+#, perl-brace-format
+msgid "Change \"{change}\" cannot require itself"
+msgstr ""
+
+#: lib/App/Sqitch/Plan.pm:543
+#, perl-brace-format
+msgid ""
+"Change \"{change}\" planned {num} change before required change "
+"\"{required}\""
+msgid_plural ""
+"Change \"{change}\" planned {num} changes before required change "
+"\"{required}\""
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/App/Sqitch/Plan.pm:552
+#, perl-brace-format
+msgid "Unknown change \"{required}\" required by change \"{change}\""
+msgstr ""
+
+#: lib/App/Sqitch/Plan.pm:562
+#, perl-brace-format
+msgid "HINT: move \"{change}\" down {num} line in {plan}"
+msgid_plural "HINT: move \"{change}\" down {num} lines in {plan}"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/App/Sqitch/Plan.pm:576
+msgid "Dependency error detected:"
+msgid_plural "Dependency errors detected:"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/App/Sqitch/Plan.pm:673
+#, perl-brace-format
+msgid "Cannot find change \"{change}\" in plan"
+msgstr ""
+
+#: lib/App/Sqitch/Plan.pm:728
+#, perl-brace-format
+msgid "Tag \"{tag}\" already exists"
+msgstr ""
+
+#: lib/App/Sqitch/Plan.pm:740
+#, perl-brace-format
+msgid "Cannot apply tag \"{tag}\" to a plan with no changes"
+msgstr ""
+
+#: lib/App/Sqitch/Plan.pm:797
+#, perl-brace-format
+msgid ""
+"Change \"{change}\" already exists in plan {file}.\n"
+"Use \"sqitch rework\" to copy and rework it"
+msgstr ""
+
+#: lib/App/Sqitch/Plan.pm:830
+#, perl-brace-format
+msgid ""
+"Change \"{change}\" does not exist in {file}.\n"
+"Use \"sqitch add {change}\" to add it to the plan"
+msgstr ""
+
+#: lib/App/Sqitch/Plan.pm:838
+#, perl-brace-format
+msgid ""
+"Cannot rework \"{change}\" without an intervening tag.\n"
+"Use \"sqitch tag\" to create a tag and try again"
+msgstr ""
+
+#: lib/App/Sqitch/Plan.pm:876
+#, perl-brace-format
+msgid "Cannot add change \"{change}\": requires unknown change \"{req}\""
+msgstr ""
+
+#: lib/App/Sqitch/Plan.pm:882
+#, perl-brace-format
+msgid "Cannot rework change \"{change}\": requires unknown change \"{req}\""
+msgstr ""
+
+#: lib/App/Sqitch/Plan.pm:905
+#, perl-brace-format
+msgid ""
+"\"{name}\" is invalid: changes must not begin with punctuation, contain \"@"
+"\", \":\", \"#\", or blanks, or end in punctuation or digits following "
+"punctuation"
+msgstr ""
+
+#: lib/App/Sqitch/Plan.pm:911
+#, perl-brace-format
+msgid ""
+"\"{name}\" is invalid: tags must not begin with punctuation, contain \"@\", "
+"\":\", \"#\", or blanks, or end in punctuation or digits following "
+"punctuation"
+msgstr ""
+
+#: lib/App/Sqitch/Plan.pm:975
+#, perl-brace-format
+msgid "\"Error closing {file}: {error}"
+msgstr ""
+
+#: lib/App/Sqitch/Plan/Change.pm:357
+#, perl-brace-format
+msgid ""
+"Please enter a note for your change. Lines starting with '#' will\n"
+"be ignored, and an empty message aborts the {command}."
+msgstr ""
+
+#: lib/App/Sqitch/Plan/Change.pm:362
+#, perl-brace-format
+msgid "Change to {command}:"
+msgstr ""
+
+#: lib/App/Sqitch/Plan/ChangeList.pm:40
+#, perl-brace-format
+msgid "The @{old} symbolic tag has been deprecated; use @{new} instead"
+msgstr ""
+
+#: lib/App/Sqitch/Plan/ChangeList.pm:130
+msgid "Change lookup failed"
+msgstr ""
+
+#: lib/App/Sqitch/Plan/Depend.pm:78
+#, perl-brace-format
+msgid "Unable to find change \"{change}\" in plan {file}"
+msgstr ""
+
+#: lib/App/Sqitch/Plan/Line.pm:115
+msgid "Aborting due to empty note"
+msgstr ""
+
+#: lib/App/Sqitch/Plan/Line.pm:131
+#, perl-brace-format
+msgid ""
+"Write a {command} note.\n"
+"Lines starting with '#' will be ignored."
+msgstr ""
+
+#: lib/App/Sqitch/Role/DBIEngine.pm:331
+#, perl-brace-format
+msgid ""
+"Cannot register \"{project}\" with URI {uri}: already exists with NULL URI"
+msgstr ""
+
+#: lib/App/Sqitch/Role/DBIEngine.pm:337
+#, perl-brace-format
+msgid ""
+"Cannot register \"{project}\" without URI: already exists with URI {uri}"
+msgstr ""
+
+#: lib/App/Sqitch/Role/DBIEngine.pm:343
+#, perl-brace-format
+msgid ""
+"Cannot register \"{project}\" with URI {uri}: already exists with URI "
+"{reg_uri}"
+msgstr ""
+
+#: lib/App/Sqitch/Role/DBIEngine.pm:361
+#, perl-brace-format
+msgid ""
+"Cannot register \"{project}\" with URI {uri}: project \"{reg_proj}\" already "
+"using that URI"
+msgstr ""
+
+#: lib/App/Sqitch/Role/TargetConfigCommand.pm:92
+#, perl-brace-format
+msgid "Unknown directory name: {dirs}"
+msgid_plural "Unknown directory names: {dirs}"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/App/Sqitch/Role/TargetConfigCommand.pm:119
+#, perl-brace-format
+msgid "URI \"{uri}\" is not a database URI"
+msgstr ""
+
+#: lib/App/Sqitch/Role/TargetConfigCommand.pm:124
+#, perl-brace-format
+msgid "No database engine in URI \"{uri}\""
+msgstr ""
+
+#: lib/App/Sqitch/Role/TargetConfigCommand.pm:128
+#, perl-brace-format
+msgid "Unknown engine \"{engine}\" in URI \"{uri}\""
+msgstr ""
+
+#: lib/App/Sqitch/Role/TargetConfigCommand.pm:291
+msgid "Cannot write a plan file without a project name"
+msgstr ""
+
+#: lib/App/Sqitch/Role/TargetConfigCommand.pm:298
+#, perl-brace-format
+msgid "Cannot initialize because {file} already exists and is not a file"
+msgstr ""
+
+#: lib/App/Sqitch/Role/TargetConfigCommand.pm:309
+#, perl-brace-format
+msgid ""
+"Cannot initialize because {file} already exists and is not a valid plan file"
+msgstr ""
+
+#: lib/App/Sqitch/Role/TargetConfigCommand.pm:315
+#, perl-brace-format
+msgid ""
+"Cannot initialize because project \"{project}\" already initialized in {file}"
+msgstr ""
+
+#: lib/App/Sqitch/Target.pm:76 lib/App/Sqitch/Target.pm:303
+#, perl-brace-format
+msgid ""
+"The core.{engine} config has been deprecated in favor of engine.{engine}.\n"
+"Run '{sqitch} engine update-config' to update your configurations."
+msgstr ""
+
+#: lib/App/Sqitch/Target.pm:274
+#, perl-brace-format
+msgid "Cannot find target \"{target}\""
+msgstr ""
+
+#: lib/App/Sqitch/Target.pm:280
+#, perl-brace-format
+msgid "No URI associated with target \"{target}\""
+msgstr ""
+
+#: lib/App/Sqitch/Target.pm:290
+#, perl-brace-format
+msgid "No engine specified by URI {uri}; URI must start with \"db:$engine:\""
+msgstr ""
+
+#: lib/App/Sqitch/Types.pm:55
+msgid "User name may not contain \"<\" or start with \"[\""
+msgstr ""
+
+#: lib/App/Sqitch/Types.pm:61
+msgid "User email may not contain \">\""
+msgstr ""

--- a/po/it_IT.po
+++ b/po/it_IT.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: App-Sqitch 0.9996\n"
 "Report-Msgid-Bugs-To: david@justatheory.com\n"
 "POT-Creation-Date: 2017-10-04 13:34+0200\n"
-"PO-Revision-Date: 2017-10-09 10:43+0200\n"
+"PO-Revision-Date: 2017-10-09 11:43+0200\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1284,40 +1284,48 @@ msgid_plural ""
 "Change \"{change}\" planned {num} changes before required change "
 "\"{required}\""
 msgstr[0] ""
+"La modifica \"{change}\" ha pianificato {num} modifica prima della richiesta "
+"\"{required}\""
 msgstr[1] ""
+"La modifica \"{change}\" ha pianificato {num} modifiche prima della "
+"richiesta \"{required}\""
 
 #: lib/App/Sqitch/Plan.pm:552
 #, perl-brace-format
 msgid "Unknown change \"{required}\" required by change \"{change}\""
 msgstr ""
+"La modifica \"{required}\" rechiesta dalla modifica \"{change}\" è "
+"sconosciuta"
 
 #: lib/App/Sqitch/Plan.pm:562
 #, perl-brace-format
 msgid "HINT: move \"{change}\" down {num} line in {plan}"
 msgid_plural "HINT: move \"{change}\" down {num} lines in {plan}"
 msgstr[0] ""
+"Suggerimento: sposta \"{change}\" di {num} linea in basso nel piano {plan}"
 msgstr[1] ""
+"Suggerimento: sposta \"{change}\" di {num} linee in basso nel piano {plan}"
 
 #: lib/App/Sqitch/Plan.pm:576
 msgid "Dependency error detected:"
 msgid_plural "Dependency errors detected:"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Errore di dipendenza rilevato:"
+msgstr[1] "Errori di dipendenza rilevati:"
 
 #: lib/App/Sqitch/Plan.pm:673
 #, perl-brace-format
 msgid "Cannot find change \"{change}\" in plan"
-msgstr ""
+msgstr "Non trovo la modifica \"{change}\" nel piano di esecuzione"
 
 #: lib/App/Sqitch/Plan.pm:728
 #, perl-brace-format
 msgid "Tag \"{tag}\" already exists"
-msgstr ""
+msgstr "Il tag \"{tag}\" esiste già"
 
 #: lib/App/Sqitch/Plan.pm:740
 #, perl-brace-format
 msgid "Cannot apply tag \"{tag}\" to a plan with no changes"
-msgstr ""
+msgstr "Non posso applicare il tag \"{tag}\" a un piano privo di modifiche"
 
 #: lib/App/Sqitch/Plan.pm:797
 #, perl-brace-format
@@ -1325,6 +1333,8 @@ msgid ""
 "Change \"{change}\" already exists in plan {file}.\n"
 "Use \"sqitch rework\" to copy and rework it"
 msgstr ""
+"La modifica \"{change}\" esiste già nel piano {file}.\n"
+"Usa \"sqitch rework\" per copiarla and rielaborarla."
 
 #: lib/App/Sqitch/Plan.pm:830
 #, perl-brace-format
@@ -1332,6 +1342,8 @@ msgid ""
 "Change \"{change}\" does not exist in {file}.\n"
 "Use \"sqitch add {change}\" to add it to the plan"
 msgstr ""
+"La modifica \"{change}\" non esiste in {file}.\n"
+"Usa \"sqitch add {change}\" per aggiungerla al piano di esecuzione."
 
 #: lib/App/Sqitch/Plan.pm:838
 #, perl-brace-format
@@ -1339,16 +1351,22 @@ msgid ""
 "Cannot rework \"{change}\" without an intervening tag.\n"
 "Use \"sqitch tag\" to create a tag and try again"
 msgstr ""
+"Non posso rielaborare \"{change}\" senza un tag di intervento.\n"
+"Usa \"sqitch tag\" per creare un tag e riprova."
 
 #: lib/App/Sqitch/Plan.pm:876
 #, perl-brace-format
 msgid "Cannot add change \"{change}\": requires unknown change \"{req}\""
 msgstr ""
+"Non posso aggiungere la modifica \"{change}\"_ è richiesta una modifica "
+"sconosciuta \"{req}\""
 
 #: lib/App/Sqitch/Plan.pm:882
 #, perl-brace-format
 msgid "Cannot rework change \"{change}\": requires unknown change \"{req}\""
 msgstr ""
+"Non posso rielaborare la modifica \"{change}\"_ è richiesta una modifica "
+"sconosciuta \"{req}\""
 
 #: lib/App/Sqitch/Plan.pm:905
 #, perl-brace-format
@@ -1357,6 +1375,9 @@ msgid ""
 "\", \":\", \"#\", or blanks, or end in punctuation or digits following "
 "punctuation"
 msgstr ""
+"\"{name}\" non è valido: le modifiche non devono iniziare con segni di "
+"punteggiatura, contenere \"@\", \":\", \"#\" o spazi bianchi o finire con "
+"segni di punteggiatura o cifre numeriche dopo segni di punteggiatura."
 
 #: lib/App/Sqitch/Plan.pm:911
 #, perl-brace-format
@@ -1365,11 +1386,14 @@ msgid ""
 "\":\", \"#\", or blanks, or end in punctuation or digits following "
 "punctuation"
 msgstr ""
+"\"{name}\" non è valido: i tag non devono iniziare con segni di "
+"punteggiatura, contenere \"@\", \":\", \"#\" o spazi bianchi o finire con "
+"segni di punteggiatura o cifre numeriche dopo segni di punteggiatura."
 
 #: lib/App/Sqitch/Plan.pm:975
 #, perl-brace-format
 msgid "\"Error closing {file}: {error}"
-msgstr ""
+msgstr "Errore nella chiusura di {file}: {error}"
 
 #: lib/App/Sqitch/Plan/Change.pm:357
 #, perl-brace-format
@@ -1377,29 +1401,32 @@ msgid ""
 "Please enter a note for your change. Lines starting with '#' will\n"
 "be ignored, and an empty message aborts the {command}."
 msgstr ""
+"per favore inserisci un commento per la tua modifica. \n"
+"Le righe che iniziano con \"#\" saranno ignorate, e una nota priva di testo "
+"farà abortire {command}."
 
 #: lib/App/Sqitch/Plan/Change.pm:362
 #, perl-brace-format
 msgid "Change to {command}:"
-msgstr ""
+msgstr "Modifica a {command}:"
 
 #: lib/App/Sqitch/Plan/ChangeList.pm:40
 #, perl-brace-format
 msgid "The @{old} symbolic tag has been deprecated; use @{new} instead"
-msgstr ""
+msgstr "Il tag simbolico @{old} è stato deprecato; usa @{new} al suo posto."
 
 #: lib/App/Sqitch/Plan/ChangeList.pm:130
 msgid "Change lookup failed"
-msgstr ""
+msgstr "Lookup della modifica fallito"
 
 #: lib/App/Sqitch/Plan/Depend.pm:78
 #, perl-brace-format
 msgid "Unable to find change \"{change}\" in plan {file}"
-msgstr ""
+msgstr "Non trovo la modifica \"{change}\" nel piano di esecuzione {file}"
 
 #: lib/App/Sqitch/Plan/Line.pm:115
 msgid "Aborting due to empty note"
-msgstr ""
+msgstr "Commento vuoto, aborto."
 
 #: lib/App/Sqitch/Plan/Line.pm:131
 #, perl-brace-format
@@ -1407,18 +1434,24 @@ msgid ""
 "Write a {command} note.\n"
 "Lines starting with '#' will be ignored."
 msgstr ""
+"Scrivi un commento per {command}.\n"
+"Le righe che iniziano con \"#\" saranno ignorate."
 
 #: lib/App/Sqitch/Role/DBIEngine.pm:331
 #, perl-brace-format
 msgid ""
 "Cannot register \"{project}\" with URI {uri}: already exists with NULL URI"
 msgstr ""
+"Non posso registrare \"{project}\" con l'URI {uri}: è già esistente con URI "
+"NULL."
 
 #: lib/App/Sqitch/Role/DBIEngine.pm:337
 #, perl-brace-format
 msgid ""
 "Cannot register \"{project}\" without URI: already exists with URI {uri}"
 msgstr ""
+"Non posso registrare \"{project}\" senza un URI: è già esistente con URI "
+"{uri}."
 
 #: lib/App/Sqitch/Role/DBIEngine.pm:343
 #, perl-brace-format
@@ -1426,6 +1459,8 @@ msgid ""
 "Cannot register \"{project}\" with URI {uri}: already exists with URI "
 "{reg_uri}"
 msgstr ""
+"Non posso registrare \"{project}\" con URI {uri}: è già esistente con URI "
+"{reg_uri}."
 
 #: lib/App/Sqitch/Role/DBIEngine.pm:361
 #, perl-brace-format
@@ -1433,49 +1468,55 @@ msgid ""
 "Cannot register \"{project}\" with URI {uri}: project \"{reg_proj}\" already "
 "using that URI"
 msgstr ""
+"Non posso registrare \"{project}\" con URI {uri}: il progetto \"{reg_proj}\" "
+"esiste già con l'URI specificato"
 
 #: lib/App/Sqitch/Role/TargetConfigCommand.pm:92
 #, perl-brace-format
 msgid "Unknown directory name: {dirs}"
 msgid_plural "Unknown directory names: {dirs}"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Directory sconosciuta: {dirs}"
+msgstr[1] "Directory sconosciuta: {dirs}"
 
 #: lib/App/Sqitch/Role/TargetConfigCommand.pm:119
 #, perl-brace-format
 msgid "URI \"{uri}\" is not a database URI"
-msgstr ""
+msgstr "L'URI \"{uri}\" non è un URI di database"
 
 #: lib/App/Sqitch/Role/TargetConfigCommand.pm:124
 #, perl-brace-format
 msgid "No database engine in URI \"{uri}\""
-msgstr ""
+msgstr "Nessun motore di database nell'URI \"{uri}\""
 
 #: lib/App/Sqitch/Role/TargetConfigCommand.pm:128
 #, perl-brace-format
 msgid "Unknown engine \"{engine}\" in URI \"{uri}\""
-msgstr ""
+msgstr "Motore \"{engine}\" sconosciuto nell'URI \"{uri}\""
 
 #: lib/App/Sqitch/Role/TargetConfigCommand.pm:291
 msgid "Cannot write a plan file without a project name"
-msgstr ""
+msgstr "Non posso scrivere un file di piano senza un nome di progetto"
 
 #: lib/App/Sqitch/Role/TargetConfigCommand.pm:298
 #, perl-brace-format
 msgid "Cannot initialize because {file} already exists and is not a file"
-msgstr ""
+msgstr "Impossibile inizializzare poiché {file} eisste già e non è un file"
 
 #: lib/App/Sqitch/Role/TargetConfigCommand.pm:309
 #, perl-brace-format
 msgid ""
 "Cannot initialize because {file} already exists and is not a valid plan file"
 msgstr ""
+"Impossibile inizializzare poiché {file} esiste già e non è un file "
+"contenente un piano di esecuzione valido."
 
 #: lib/App/Sqitch/Role/TargetConfigCommand.pm:315
 #, perl-brace-format
 msgid ""
 "Cannot initialize because project \"{project}\" already initialized in {file}"
 msgstr ""
+"Impossibile inziializzare poiché il progetto \"{project}\" è già stato "
+"inizializzato in {file}"
 
 #: lib/App/Sqitch/Target.pm:76 lib/App/Sqitch/Target.pm:303
 #, perl-brace-format
@@ -1483,26 +1524,31 @@ msgid ""
 "The core.{engine} config has been deprecated in favor of engine.{engine}.\n"
 "Run '{sqitch} engine update-config' to update your configurations."
 msgstr ""
+"La configurazione core.{engine} è stata deprecata a favore di engine."
+"{engine}.\n"
+"Esegui '{sqitch} engine update-config` per aggiornare la tua configurazione."
 
 #: lib/App/Sqitch/Target.pm:274
 #, perl-brace-format
 msgid "Cannot find target \"{target}\""
-msgstr ""
+msgstr "Non posso trovare il target specificato \"{target}\""
 
 #: lib/App/Sqitch/Target.pm:280
 #, perl-brace-format
 msgid "No URI associated with target \"{target}\""
-msgstr ""
+msgstr "Nessun URI associato al target \"{target}\""
 
 #: lib/App/Sqitch/Target.pm:290
 #, perl-brace-format
 msgid "No engine specified by URI {uri}; URI must start with \"db:$engine:\""
 msgstr ""
+"Nessun motore specificato nell'URI {uri}; gli URI devono iniziare con \"db:"
+"$engine:\"."
 
 #: lib/App/Sqitch/Types.pm:55
 msgid "User name may not contain \"<\" or start with \"[\""
-msgstr ""
+msgstr "Lo username non può contenere \"<\" o iniziare con \"|\""
 
 #: lib/App/Sqitch/Types.pm:61
 msgid "User email may not contain \">\""
-msgstr ""
+msgstr "L'email utente non può contenere \">\"."

--- a/po/it_IT.po
+++ b/po/it_IT.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: App-Sqitch 0.9996\n"
 "Report-Msgid-Bugs-To: david@justatheory.com\n"
 "POT-Creation-Date: 2017-10-04 13:34+0200\n"
-"PO-Revision-Date: 2017-10-04 14:02+0200\n"
+"PO-Revision-Date: 2017-10-09 10:43+0200\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -342,53 +342,53 @@ msgstr ""
 
 #: lib/App/Sqitch/Command/engine.pm:276
 msgid "Target"
-msgstr ""
+msgstr "Target"
 
 #: lib/App/Sqitch/Command/engine.pm:277 lib/App/Sqitch/Command/target.pm:255
 msgid "Registry"
-msgstr ""
+msgstr "Registro"
 
 #: lib/App/Sqitch/Command/engine.pm:278 lib/App/Sqitch/Command/target.pm:256
 msgid "Client"
-msgstr ""
+msgstr "Client"
 
 #: lib/App/Sqitch/Command/engine.pm:279 lib/App/Sqitch/Command/target.pm:257
 msgid "Top Directory"
-msgstr ""
+msgstr "Directory superiore"
 
 #: lib/App/Sqitch/Command/engine.pm:280 lib/App/Sqitch/Command/target.pm:258
 msgid "Plan File"
-msgstr ""
+msgstr "File di piano"
 
 #: lib/App/Sqitch/Command/engine.pm:281 lib/App/Sqitch/Command/target.pm:259
 msgid "Extension"
-msgstr ""
+msgstr "Estensione"
 
 #: lib/App/Sqitch/Command/engine.pm:282 lib/App/Sqitch/Command/target.pm:260
 #: lib/App/Sqitch/ItemFormatter.pm:62
 msgid "Revert"
-msgstr ""
+msgstr "Ripristina"
 
 #: lib/App/Sqitch/Command/engine.pm:283 lib/App/Sqitch/Command/target.pm:261
 #: lib/App/Sqitch/ItemFormatter.pm:61
 msgid "Deploy"
-msgstr ""
+msgstr "Deploy"
 
 #: lib/App/Sqitch/Command/engine.pm:284 lib/App/Sqitch/Command/target.pm:262
 msgid "Verify"
-msgstr ""
+msgstr "Verifica"
 
 #: lib/App/Sqitch/Command/engine.pm:285 lib/App/Sqitch/Command/target.pm:263
 msgid "Reworked"
-msgstr ""
+msgstr "Rilavorato"
 
 #: lib/App/Sqitch/Command/engine.pm:292 lib/App/Sqitch/Command/target.pm:270
 msgid "Script Directories"
-msgstr ""
+msgstr "Directory degli script"
 
 #: lib/App/Sqitch/Command/engine.pm:293 lib/App/Sqitch/Command/target.pm:271
 msgid "Reworked Script Directories"
-msgstr ""
+msgstr "Directory degli script di rilavorazione"
 
 #: lib/App/Sqitch/Command/engine.pm:334
 #, perl-brace-format
@@ -457,205 +457,208 @@ msgstr "Nessun logger di eventi per {db}"
 #: lib/App/Sqitch/Command/log.pm:243 lib/App/Sqitch/Command/status.pm:116
 #, perl-brace-format
 msgid "On database {db}"
-msgstr ""
+msgstr "Sul database {db}"
 
 #: lib/App/Sqitch/Command/plan.pm:163
 #, perl-brace-format
 msgid "Unknown plan format \"{format}\""
-msgstr ""
+msgstr "Formato \"{format}\" del piano di esecuzione sconosciuto "
 
 #: lib/App/Sqitch/Command/plan.pm:192 lib/App/Sqitch/Command/upgrade.pm:39
 #, perl-brace-format
 msgid "Too many targets specified; using {target}"
-msgstr ""
+msgstr "Troppi target specificati; si usa {target}"
 
 #: lib/App/Sqitch/Command/plan.pm:202
 #, perl-brace-format
 msgid "No changes in {file}"
-msgstr ""
+msgstr "Nessun modifica in {file}"
 
 #: lib/App/Sqitch/Command/plan.pm:220
 #, perl-brace-format
 msgid "Project: {project}"
-msgstr ""
+msgstr "Progetto: {project}"
 
 #: lib/App/Sqitch/Command/plan.pm:221
 #, perl-brace-format
 msgid "File:    {file}"
-msgstr ""
+msgstr "File:    {file}"
 
 #: lib/App/Sqitch/Command/rebase.pm:51 lib/App/Sqitch/Command/verify.pm:65
 #, perl-brace-format
 msgid "Option --{old} has been deprecated; use --{new} instead"
-msgstr ""
+msgstr "L'opzione --{old} è deprecata; usa --{new} al suo posto"
 
 #: lib/App/Sqitch/Command/rebase.pm:80
 #, perl-brace-format
 msgid "Too many changes specified; rebasing onto \"{onto}\" up to \"{upto}\""
 msgstr ""
+"Troppe modifiche specificate; riposiziono da \"{onto}\" fino a \"{upto}\""
 
 #: lib/App/Sqitch/Command/revert.pm:124
 #, perl-brace-format
 msgid "Too many changes specified; reverting to \"{change}\""
-msgstr ""
+msgstr "Troppe modifiche specificate; ritorno a \"{change}\""
 
 #: lib/App/Sqitch/Command/rework.pm:153
 msgid "rework"
-msgstr ""
+msgstr "rilavoro"
 
 #: lib/App/Sqitch/Command/rework.pm:171
 #, perl-brace-format
 msgid "Added \"{change}\" to {file}."
-msgstr ""
+msgstr "\"{change}\" aggiunta a {file}."
 
 #: lib/App/Sqitch/Command/rework.pm:179
 msgid "Modify this file as appropriate:"
 msgid_plural "Modify these files as appropriate:"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Modifica questo file nel modo appropriato:"
+msgstr[1] "Modifica questi file nel modo appropriato:"
 
 #: lib/App/Sqitch/Command/rework.pm:199
 #, perl-brace-format
 msgid "Skipped {dest}: {src} does not exist"
-msgstr ""
+msgstr "Salto {dest}: {src} non esiste"
 
 #: lib/App/Sqitch/Command/rework.pm:208
 #, perl-brace-format
 msgid "Cannot copy {src} to {dest}: {error}"
-msgstr ""
+msgstr "Non posso copiare {src} in {dest}: {error}"
 
 #: lib/App/Sqitch/Command/rework.pm:215
 #, perl-brace-format
 msgid "Copied {src} to {dest}"
-msgstr ""
+msgstr "Copiato {src} in {dest}"
 
 #: lib/App/Sqitch/Command/show.pm:70 lib/App/Sqitch/Plan/ChangeList.pm:106
 #, perl-brace-format
 msgid "Unknown tag \"{tag}\""
-msgstr ""
+msgstr "Tag \"{tag}\" sconosciuto"
 
 #: lib/App/Sqitch/Command/show.pm:78
 #, perl-brace-format
 msgid "Unknown object type \"{type}"
-msgstr ""
+msgstr "Tipo di oggetto \"{type}\" sconosciuto"
 
 #: lib/App/Sqitch/Command/show.pm:86
 #, perl-brace-format
 msgid "Unknown change \"{change}\""
-msgstr ""
+msgstr "Modifica \"{change}\" sconosciuta"
 
 #: lib/App/Sqitch/Command/show.pm:101
 #, perl-brace-format
 msgid "File \"{path}\" does not exist"
-msgstr ""
+msgstr "Il file \"{path}\" non esiste"
 
 #: lib/App/Sqitch/Command/show.pm:103
 #, perl-brace-format
 msgid "\"{path}\" is not a file"
-msgstr ""
+msgstr "\"{path}\" non è un file"
 
 #: lib/App/Sqitch/Command/status.pm:74
 msgid "Database not initialized for Sqitch"
-msgstr ""
+msgstr "Database non inizializzato per Sqitch"
 
 #: lib/App/Sqitch/Command/status.pm:77
 msgid "No projects registered"
-msgstr ""
+msgstr "Nessun progetto registrato"
 
 #: lib/App/Sqitch/Command/status.pm:79
 #, perl-brace-format
 msgid "Use --project to select which project to query: {projects}"
-msgstr ""
+msgstr "Usa --project per selezionare  quale progetto interrogare: {projects}"
 
 #: lib/App/Sqitch/Command/status.pm:80 lib/App/Sqitch/Command/status.pm:203
 #: lib/App/Sqitch/Role/TargetConfigCommand.pm:95
 msgid ", "
-msgstr ""
+msgstr ","
 
 #: lib/App/Sqitch/Command/status.pm:135 lib/App/Sqitch/Engine.pm:346
 msgid "No changes deployed"
-msgstr ""
+msgstr "Nessuna modifica deployata"
 
 #: lib/App/Sqitch/Command/status.pm:153
 #, perl-brace-format
 msgid "Status unknown. Use --plan-file to assess \"{project}\" status"
 msgstr ""
+"Stato sconosciuto. Usa --plan-file per impostare lo stato di \"{project}\""
 
 #: lib/App/Sqitch/Command/status.pm:187
 #, perl-brace-format
 msgid "Project:  {project}"
-msgstr ""
+msgstr "Progetto:  {project}"
 
 #: lib/App/Sqitch/Command/status.pm:191
 #, perl-brace-format
 msgid "Change:   {change_id}"
-msgstr ""
+msgstr "Modifica:   {change_id}"
 
 #: lib/App/Sqitch/Command/status.pm:195
 #, perl-brace-format
 msgid "Name:     {change}"
-msgstr ""
+msgstr "Nome:     {change}"
 
 #: lib/App/Sqitch/Command/status.pm:200
 #, perl-brace-format
 msgid "Tag:      {tags}"
 msgid_plural "Tags:     {tags}"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Tag:      {tags}"
+msgstr[1] "Tag:      {tags}"
 
 #: lib/App/Sqitch/Command/status.pm:208
 #, perl-brace-format
 msgid "Deployed: {date}"
-msgstr ""
+msgstr "Deployato: {date}"
 
 #: lib/App/Sqitch/Command/status.pm:214
 #, perl-brace-format
 msgid "By:       {name} <{email}>"
-msgstr ""
+msgstr "Autore:       {name} <{email}>"
 
 #: lib/App/Sqitch/Command/status.pm:237
 msgid "Change:"
 msgid_plural "Changes:"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Modifica:"
+msgstr[1] "Modifiche:"
 
 #: lib/App/Sqitch/Command/status.pm:266
 msgid "Tags: None."
-msgstr ""
+msgstr "Tag: None"
 
 #: lib/App/Sqitch/Command/status.pm:270
 msgid "Tag:"
 msgid_plural "Tags:"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Tag:"
+msgstr[1] "Tag:"
 
 #: lib/App/Sqitch/Command/status.pm:296
 #, perl-brace-format
 msgid "Cannot find this change in {file}"
-msgstr ""
+msgstr "Non trovo questa modifica in {file}"
 
 #: lib/App/Sqitch/Command/status.pm:299
 msgid "Make sure you are connected to the proper database for this project."
 msgstr ""
+"Assicurati di essere collegato al database corretto per questo progetto."
 
 #: lib/App/Sqitch/Command/status.pm:305 lib/App/Sqitch/Engine.pm:179
 msgid "Nothing to deploy (up-to-date)"
-msgstr ""
+msgstr "Niente da deployare (tutto già aggiornato)"
 
 #: lib/App/Sqitch/Command/status.pm:308 lib/App/Sqitch/Engine.pm:495
 msgid "Undeployed change:"
 msgid_plural "Undeployed changes:"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Modifica rimosse dal deploy:"
+msgstr[1] "Modifiche rimosse dal deploy:"
 
 #: lib/App/Sqitch/Command/tag.pm:80
 msgid "tag"
-msgstr ""
+msgstr "tag"
 
 #: lib/App/Sqitch/Command/tag.pm:88
 #, perl-brace-format
 msgid "Tagged \"{change}\" with {tag} in {file}"
-msgstr ""
+msgstr "\"{change}\" marcata con {tag} in {file}"
 
 #: lib/App/Sqitch/Command/tag.pm:100
 #, perl-brace-format
@@ -663,239 +666,247 @@ msgid ""
 "Name \"{name}\" identifies a target; use \"--tag {name}\" to use it for the "
 "tag name"
 msgstr ""
+"Il nome \"{name} identifica un target; usa \"--tag {name}\" per usarlo come "
+"nome di tag"
 
 #: lib/App/Sqitch/Command/target.pm:71
 #, perl-brace-format
 msgid "Target \"{target}\" already exists"
-msgstr ""
+msgstr "Il target \"{target}\" esiste già."
 
 #: lib/App/Sqitch/Command/target.pm:106
 #, perl-brace-format
 msgid "Missing Target \"{target}\"; use \"{command}\" to add it"
-msgstr ""
+msgstr "Il target \"{target}\" è mancante; usa \"{command}\" per aggiungerlo."
 
 #: lib/App/Sqitch/Command/target.pm:198 lib/App/Sqitch/Command/target.pm:211
 #, perl-brace-format
 msgid "Cannot rename target \"{target}\" because it's referenced by: {engines}"
 msgstr ""
+"Non posso rinominare il target \"{target}\" perché è referenziato da: "
+"{engines}"
 
 #: lib/App/Sqitch/Command/target.pm:254
 msgid "URI"
-msgstr ""
+msgstr "URI"
 
 #: lib/App/Sqitch/Command/upgrade.pm:48
 #, perl-brace-format
 msgid "Upgrading registry {registry} to version {version}"
-msgstr ""
+msgstr "Aggiorno il registro {registry} alla versione {version}"
 
 #: lib/App/Sqitch/Command/upgrade.pm:55
 #, perl-brace-format
 msgid "Registry {registry} is up-to-date at version {version}"
-msgstr ""
+msgstr "Il registro {registry} è aggiornato alla versione {version}"
 
 #: lib/App/Sqitch/Command/verify.pm:102
 #, perl-brace-format
 msgid "Too many changes specified; verifying from \"{from}\" to \"{to}\""
-msgstr ""
+msgstr "Troppe modifiche specificate; verfica da \"{from}\" a \"{to}\""
 
 #: lib/App/Sqitch/Config.pm:26
 msgid "Could not determine home directory"
-msgstr ""
+msgstr "Non riesco a stabiliare la home directory"
 
 #: lib/App/Sqitch/DateTime.pm:32 lib/App/Sqitch/DateTime.pm:70
 #, perl-brace-format
 msgid "Unknown date format \"{format}\""
-msgstr ""
+msgstr "Formato data \"{format}\" sconosciuto"
 
 #: lib/App/Sqitch/Engine.pm:112 lib/App/Sqitch/Engine.pm:124
 #: lib/App/Sqitch/Target.pm:252
 msgid "No engine specified; use --engine or set core.engine"
-msgstr ""
+msgstr "Nessun motore specificato: usa --engine o imposta core.engine"
 
 #: lib/App/Sqitch/Engine.pm:146
 #, perl-brace-format
 msgid "{driver} required to manage {engine}"
-msgstr ""
+msgstr "{driver} è necessario per gestire {engine}"
 
 #: lib/App/Sqitch/Engine.pm:159
 msgid "Nothing to deploy (empty plan)"
-msgstr ""
+msgstr "Niente da dployare (piano esecuzione vuoto)"
 
 #: lib/App/Sqitch/Engine.pm:163 lib/App/Sqitch/Engine.pm:256
 #: lib/App/Sqitch/Plan.pm:735 lib/App/Sqitch/Plan/ChangeList.pm:155
 #, perl-brace-format
 msgid "Unknown change: \"{change}\""
-msgstr ""
+msgstr "Modifica \"{change}\" sconosciuta"
 
 #: lib/App/Sqitch/Engine.pm:170
 #, perl-brace-format
 msgid "Nothing to deploy (already at \"{change}\")"
-msgstr ""
+msgstr "Niente da deployare (già a \"{change}\")"
 
 #: lib/App/Sqitch/Engine.pm:188
 #, perl-brace-format
 msgid "Adding registry tables to {destination}"
-msgstr ""
+msgstr "Aggiungo le tabelle di registro a {destination}"
 
 #: lib/App/Sqitch/Engine.pm:197
 msgid "Cannot deploy to an earlier change; use \"revert\" instead"
-msgstr ""
+msgstr "Non posso effettuare deploy a una modifica precedente; usa \"revert\"."
 
 #: lib/App/Sqitch/Engine.pm:205
 #, perl-brace-format
 msgid "Deploying changes through {change} to {destination}"
-msgstr ""
+msgstr "Eseguo deploy delle modifiche da {change} a {destination}"
 
 #: lib/App/Sqitch/Engine.pm:209
 #, perl-brace-format
 msgid "Deploying changes to {destination}"
-msgstr ""
+msgstr "Effettuo deploy modifiche a {destination}"
 
 #: lib/App/Sqitch/Engine.pm:222
 #, perl-brace-format
 msgid "Unknown deployment mode: \"{mode}\""
-msgstr ""
+msgstr "Modalità di deploy \"{mode}\" sconosciuta"
 
 #: lib/App/Sqitch/Engine.pm:250
 #, perl-brace-format
 msgid "Change not deployed: \"{change}\""
-msgstr ""
+msgstr "Modifica non inclusa nel deploy: \"{change}\""
 
 #: lib/App/Sqitch/Engine.pm:266
 #, perl-brace-format
 msgid "No changes deployed since: \"{change}\""
-msgstr ""
+msgstr "Nessuna modifica per cui effettuare deploy da \"{change}\""
 
 #: lib/App/Sqitch/Engine.pm:274
 #, perl-brace-format
 msgid "Reverting changes to {change} from {destination}"
-msgstr ""
+msgstr "Annullo modifiche da {destination} a {change}"
 
 #: lib/App/Sqitch/Engine.pm:281 lib/App/Sqitch/Engine.pm:305
 msgid "Nothing reverted"
-msgstr ""
+msgstr "Niente è stato annullato"
 
 #: lib/App/Sqitch/Engine.pm:284
 #, perl-brace-format
 msgid "Revert changes to {change} from {destination}?"
-msgstr ""
+msgstr "Annullo modifiche da {destination} a {change}"
 
 #: lib/App/Sqitch/Engine.pm:293
 msgid "Nothing to revert (nothing deployed)"
-msgstr ""
+msgstr "Niente da annullare (niente per cui effettuare deploy)"
 
 #: lib/App/Sqitch/Engine.pm:299
 #, perl-brace-format
 msgid "Reverting all changes from {destination}"
-msgstr ""
+msgstr "Annullo tutte le modifiche da {destination}"
 
 #: lib/App/Sqitch/Engine.pm:308
 #, perl-brace-format
 msgid "Revert all changes from {destination}?"
-msgstr ""
+msgstr "Annullo tutte le modifiche da {destination}?"
 
 #: lib/App/Sqitch/Engine.pm:339
 #, perl-brace-format
 msgid "Verifying {destination}"
-msgstr ""
+msgstr "Veifico {destination}"
 
 #: lib/App/Sqitch/Engine.pm:347
 msgid "Nothing to verify (no planned or deployed changes)"
 msgstr ""
+"Niente da verificare (nessuna modifica pianificata o per cui effettuare "
+"deploy)"
 
 #: lib/App/Sqitch/Engine.pm:357
 msgid "There are deployed changes, but none planned!"
-msgstr ""
+msgstr "Ci sono modifiche incluse nel deploy, ma nessuna pianificata!"
 
 #: lib/App/Sqitch/Engine.pm:377
 msgid "Verify Summary Report"
-msgstr ""
+msgstr "Report Sommario di verifica"
 
 #: lib/App/Sqitch/Engine.pm:380
 #, perl-brace-format
 msgid "Changes: {number}"
-msgstr ""
+msgstr "Modifiche: {number}"
 
 #: lib/App/Sqitch/Engine.pm:381
 #, perl-brace-format
 msgid "Errors:  {number}"
-msgstr ""
+msgstr "Errori: {number}"
 
 #: lib/App/Sqitch/Engine.pm:382
 msgid "Verify failed"
-msgstr ""
+msgstr "Verifica fallita"
 
 #: lib/App/Sqitch/Engine.pm:387
 msgid "Verify successful"
-msgstr ""
+msgstr "Verifica riuscita"
 
 #: lib/App/Sqitch/Engine.pm:400
 #, perl-brace-format
 msgid "Change \"{change}\" has not been deployed"
-msgstr ""
+msgstr "Modifica \"{change}\" non deployata"
 
 #: lib/App/Sqitch/Engine.pm:403
 #, perl-brace-format
 msgid "Cannot find \"{change}\" in the database or the plan"
-msgstr ""
+msgstr "Non posso trovare \"{change}\" nel database o nel piano di esecuzione"
 
 #: lib/App/Sqitch/Engine.pm:410
 #, perl-brace-format
 msgid "Change \"{change}\" is deployed, but not planned"
-msgstr ""
+msgstr "La modifica \"{change}\" è deployata ma non pianificata"
 
 #: lib/App/Sqitch/Engine.pm:454
 msgid "Out of order"
-msgstr ""
+msgstr "Fuori servizio"
 
 #: lib/App/Sqitch/Engine.pm:460
 msgid "Not present in the plan"
-msgstr ""
+msgstr "Non presente nel piano di esecuzione"
 
 #: lib/App/Sqitch/Engine.pm:471 lib/App/Sqitch/Engine.pm:483
 #: lib/App/Sqitch/Engine.pm:963 lib/App/Sqitch/Engine.pm:993
 msgid "not ok"
-msgstr ""
+msgstr "Non OK"
 
 #: lib/App/Sqitch/Engine.pm:471 lib/App/Sqitch/Engine.pm:941
 #: lib/App/Sqitch/Engine.pm:983
 msgid "ok"
-msgstr ""
+msgstr "OK"
 
 #: lib/App/Sqitch/Engine.pm:485
 msgid "Not deployed"
-msgstr ""
+msgstr "Non deployato"
 
 #: lib/App/Sqitch/Engine.pm:517
 #, perl-brace-format
 msgid "Verify script \"{script}\" failed."
-msgstr ""
+msgstr "Script di verifica \"{script}\" fallito"
 
 #: lib/App/Sqitch/Engine.pm:526
 #, perl-brace-format
 msgid "Verify script {file} does not exist"
-msgstr ""
+msgstr "Lo script di verifica {file} non esiste"
 
 #: lib/App/Sqitch/Engine.pm:567
 #, perl-brace-format
 msgid "Conflicts with previously deployed change: {changes}"
 msgid_plural "Conflicts with previously deployed changes: {changes}"
 msgstr[0] ""
+"Ci sono conflitti con la modifica precdedentemente deployata: {changes}"
 msgstr[1] ""
+"Ci sono conflitti con le modifiche precdedentemente deployate: {changes}"
 
 #: lib/App/Sqitch/Engine.pm:574
 #, perl-brace-format
 msgid "Missing required change: {changes}"
 msgid_plural "Missing required changes: {changes}"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Modifica richiesta non trovata: {changes}"
+msgstr[1] "Modifiche richieste non trovate: {changes}"
 
 #: lib/App/Sqitch/Engine.pm:586
 #, perl-brace-format
 msgid "Change \"{changes}\" has already been deployed"
 msgid_plural "Changes have already been deployed: {changes}"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "La modifica \"{changes}\" è già stata deployata"
+msgstr[1] "Le modifiche \"{changes}\" sono già state deployate"
 
 #: lib/App/Sqitch/Engine.pm:609
 #, perl-brace-format
@@ -903,54 +914,60 @@ msgid "Change \"{change}\" required by currently deployed change: {changes}"
 msgid_plural ""
 "Change \"{change}\" required by currently deployed changes: {changes}"
 msgstr[0] ""
+"La modifica \"{change}\" è richiesta dalla modifica correntemente deployata: "
+"{changes}"
 msgstr[1] ""
+"La modifica \"{change}\" è richiesta dalle modifiche correntemente "
+"deployate: {changes}"
 
 #: lib/App/Sqitch/Engine.pm:632
 #, perl-brace-format
 msgid "Invalid dependency: {dependency}"
-msgstr ""
+msgstr "Dipendenza {dependency} non valida"
 
 #: lib/App/Sqitch/Engine.pm:766 lib/App/Sqitch/Plan/ChangeList.pm:122
 #, perl-brace-format
 msgid ""
 "Change \"{change}\" is ambiguous. Please specify a tag-qualified change:"
 msgstr ""
+"La modifica \"{change}\" è ambigua. Per favore indica la modifica con un tag."
 
 #: lib/App/Sqitch/Engine.pm:781
 msgid "Change Lookup Failed"
-msgstr ""
+msgstr "Recupero della modifica fallito"
 
 #: lib/App/Sqitch/Engine.pm:802
 #, perl-brace-format
 msgid "Reverting to {change}"
-msgstr ""
+msgstr "Ritorno a {change}"
 
 #: lib/App/Sqitch/Engine.pm:803
 msgid "Reverting all changes"
-msgstr ""
+msgstr "Annullo tutte le modifiche"
 
 #: lib/App/Sqitch/Engine.pm:811
 msgid "The schema will need to be manually repaired"
-msgstr ""
+msgstr "Lo schema richiede una riparazione manuale."
 
 #: lib/App/Sqitch/Engine.pm:815 lib/App/Sqitch/Engine.pm:957
 msgid "Deploy failed"
-msgstr ""
+msgstr "Deploy fallito"
 
 #: lib/App/Sqitch/Engine.pm:872
 #, perl-brace-format
 msgid "Cannot find change {id} ({change}) in {file}"
-msgstr ""
+msgstr "Non trovo la modifica {id} ({change}) in {file}"
 
 #: lib/App/Sqitch/Engine.pm:913
 #, perl-brace-format
 msgid "Updating legacy change and tag IDs in {destination}"
-msgstr ""
+msgstr "Aggiorno la modifica legacy e gli ID dei tag in {destination}"
 
 #: lib/App/Sqitch/Engine.pm:1026
 #, perl-brace-format
 msgid "No registry found in {destination}. Have you ever deployed?"
 msgstr ""
+"Nessun registro trovato in {destination}. E' mai stato fatto un deploy prima?"
 
 #: lib/App/Sqitch/Engine.pm:1031
 #, perl-brace-format
@@ -958,6 +975,8 @@ msgid ""
 "Registry version is {old} but {new} is the latest known. Please upgrade "
 "Sqitch"
 msgstr ""
+"La versione di registro è {old} ma {new} è la piu' recente conosciuta. Per "
+"favore aggiorna Sqitch."
 
 #: lib/App/Sqitch/Engine.pm:1037
 #, perl-brace-format
@@ -965,6 +984,8 @@ msgid ""
 "Registry is at version {old} but latest is {new}. Please run the \"upgrade\" "
 "conmand"
 msgstr ""
+"La versione di registro è {old} ma {new} è la piu' recente conosciuta. Per "
+"favore esegui il comando \"upgrade\"."
 
 #: lib/App/Sqitch/Engine.pm:1052
 #, perl-brace-format
@@ -972,269 +993,287 @@ msgid ""
 "Registry version is {old} but {new} is the latest known. Please upgrade "
 "Sqitch."
 msgstr ""
+"La versione di registro è {old} ma {new} è la piu' recente conosciuta. Per "
+"favore aggiorna Sqitch."
 
 #: lib/App/Sqitch/Engine.pm:1067
 #, perl-brace-format
 msgid "Cannot upgrade to {version}: Cannot find upgrade script \"{file}\""
 msgstr ""
+"Non posso aggiornare a {version}: non trovo lo script \"{file}\" per "
+"l'aggiornamento"
 
 #: lib/App/Sqitch/Engine.pm:1076
 #, perl-brace-format
 msgid "From {old} to {new}"
-msgstr ""
+msgstr "Da {old} a {new}"
 
 #: lib/App/Sqitch/Engine/firebird.pm:204 lib/App/Sqitch/Engine/mysql.pm:248
 #: lib/App/Sqitch/Engine/sqlite.pm:158
 #, perl-brace-format
 msgid "Sqitch database {database} already initialized"
-msgstr ""
+msgstr "Database Sqitch già inizialiatto su {database}"
 
 #: lib/App/Sqitch/Engine/firebird.pm:223
 #, perl-brace-format
 msgid "Cannot create database {database}: {error}"
-msgstr ""
+msgstr "Non posso creare il database {database}: {error}"
 
 #: lib/App/Sqitch/Engine/firebird.pm:237 lib/App/Sqitch/Engine/sqlite.pm:127
 #, perl-brace-format
 msgid "Database name missing in URI {uri}"
-msgstr ""
+msgstr "Il nome di database non è specificato nell'URI {uri}"
 
 #: lib/App/Sqitch/Engine/firebird.pm:880 lib/App/Sqitch/Engine/firebird.pm:897
 #: lib/App/Sqitch/Engine/firebird.pm:908
 #, perl-brace-format
 msgid "Cannot dup STDERR: {error}"
-msgstr ""
+msgstr "Non posso effettuare la dup su STDERR: {error}"
 
 #: lib/App/Sqitch/Engine/firebird.pm:884
 #, perl-brace-format
 msgid "Cannot reirect STDERR: {error}"
-msgstr ""
+msgstr "Non posso redirezionare STDERR: {error}"
 
 #: lib/App/Sqitch/Engine/firebird.pm:911
 msgid ""
 "Unable to locate Firebird ISQL; set \"engine.firebird.client\" via sqitch "
 "config"
 msgstr ""
+"Non trovo Firebirs ISQL: imposta \"engine.firebird.client\" attraverso "
+"\"sqitch config\""
 
 #: lib/App/Sqitch/Engine/mysql.pm:110
 #, perl-brace-format
 msgid ""
 "Sqitch requires {rdbms} {want_version} or higher; this is {have_version}"
 msgstr ""
+"Sqitch richiede {rdbms} alla version {want_version} o superiore: questa è la "
+"versione {have_version}"
 
 #: lib/App/Sqitch/Engine/mysql.pm:142
 #, perl-brace-format
 msgid "Database name missing in URI \"{uri}\""
-msgstr ""
+msgstr "Il nome di database non è specificato nell'URI {uri}"
 
 #: lib/App/Sqitch/Engine/oracle.pm:443
 msgid "Sqitch already initialized"
-msgstr ""
+msgstr "Sqitch è già stato inizializzato"
 
 #: lib/App/Sqitch/Engine/oracle.pm:573
 #, perl-brace-format
 msgid "Cannot remove {file}: {error}"
-msgstr ""
+msgstr "Non posso rimuovere {file}: {error}"
 
 #: lib/App/Sqitch/Engine/oracle.pm:582
 #, perl-brace-format
 msgid "Cannot copy {file} to {alias}: {error}"
-msgstr ""
+msgstr "Non posso copiare {file} su {alias}: {error}"
 
 #: lib/App/Sqitch/Engine/oracle.pm:591
 #, perl-brace-format
 msgid "Cannot symlink {file} to {alias}: {error}"
-msgstr ""
+msgstr "Non posso creare un link simbolico da {file} a {alias}: {error}"
 
 #: lib/App/Sqitch/Engine/pg.pm:169 lib/App/Sqitch/Engine/vertica.pm:154
 #, perl-brace-format
 msgid "Sqitch schema \"{schema}\" already exists"
-msgstr ""
+msgstr "Lo schema \"{schema}\" per Sqitch esiste già."
 
 #: lib/App/Sqitch/Engine/sqlite.pm:98
 #, perl-brace-format
 msgid ""
 "Sqitch requires SQLite 3.7.11 or later; DBD::SQLite was built with {version}"
 msgstr ""
+"Sqitch richiede SQLite 3.7.11 or superiore; DBD::SQLite non è stato "
+"compilato per {version}"
 
 #: lib/App/Sqitch/Engine/sqlite.pm:121
 #, perl-brace-format
 msgid "Sqitch requires SQLite 3.3.9 or later; {client} is {version}"
-msgstr ""
+msgstr "Sqitch richiede SQLite 3.3.9 o superiore: {client} è {version}"
 
 #: lib/App/Sqitch/ItemFormatter.pm:63
 msgid "Fail"
-msgstr ""
+msgstr "Fallito"
 
 #: lib/App/Sqitch/ItemFormatter.pm:68
 msgid "deploy"
-msgstr ""
+msgstr "deploy"
 
 #: lib/App/Sqitch/ItemFormatter.pm:69
 msgid "revert"
-msgstr ""
+msgstr "annullo"
 
 #: lib/App/Sqitch/ItemFormatter.pm:70
 msgid "fail"
-msgstr ""
+msgstr "fallito"
 
 #: lib/App/Sqitch/ItemFormatter.pm:75
 msgid "Event:    "
-msgstr ""
+msgstr "Evento:"
 
 #: lib/App/Sqitch/ItemFormatter.pm:76
 msgid "Change:   "
-msgstr ""
+msgstr "Modifica:"
 
 #: lib/App/Sqitch/ItemFormatter.pm:77
 msgid "Committer:"
-msgstr ""
+msgstr "Committer:"
 
 #: lib/App/Sqitch/ItemFormatter.pm:78
+#, fuzzy
 msgid "Planner:  "
-msgstr ""
+msgstr "Esecutore:"
 
 #: lib/App/Sqitch/ItemFormatter.pm:79
 msgid "By:       "
-msgstr ""
+msgstr "Autore:"
 
 #: lib/App/Sqitch/ItemFormatter.pm:80
 msgid "Date:     "
-msgstr ""
+msgstr "Data:"
 
 #: lib/App/Sqitch/ItemFormatter.pm:81
 msgid "Committed:"
-msgstr ""
+msgstr "Committato:"
 
 #: lib/App/Sqitch/ItemFormatter.pm:82
 msgid "Planned:  "
-msgstr ""
+msgstr "Pianificato:"
 
 #: lib/App/Sqitch/ItemFormatter.pm:83
 msgid "Name:     "
-msgstr ""
+msgstr "Nome:"
 
 #: lib/App/Sqitch/ItemFormatter.pm:84
 msgid "Project:  "
-msgstr ""
+msgstr "Progetto:"
 
 #: lib/App/Sqitch/ItemFormatter.pm:85
 msgid "Email:    "
-msgstr ""
+msgstr "Email:"
 
 #: lib/App/Sqitch/ItemFormatter.pm:86 lib/App/Sqitch/ItemFormatter.pm:176
 msgid "Requires: "
-msgstr ""
+msgstr "Richiede:"
 
 #: lib/App/Sqitch/ItemFormatter.pm:87 lib/App/Sqitch/ItemFormatter.pm:187
 msgid "Conflicts:"
-msgstr ""
+msgstr "Conflitti:"
 
 #: lib/App/Sqitch/ItemFormatter.pm:89
+#, fuzzy
 msgid "No label passed to the _ format"
-msgstr ""
+msgstr "Nessuna etichetta passata al formato _"
 
 #: lib/App/Sqitch/ItemFormatter.pm:93
-#, perl-brace-format
+#, fuzzy, perl-brace-format
 msgid "Unknown label \"{label}\" passed to the _ format"
-msgstr ""
+msgstr "Etichetta \"{label}\" sconosciuta passata al formato _"
 
 #: lib/App/Sqitch/ItemFormatter.pm:150
 #, perl-brace-format
 msgid "{color} is not a valid ANSI color"
-msgstr ""
+msgstr "{color} non è un colore ANSI valido"
 
 #: lib/App/Sqitch/ItemFormatter.pm:193
 #, perl-brace-format
 msgid "{attr} is not a valid change attribute"
-msgstr ""
+msgstr "{attr} non è un attributo valido"
 
 #: lib/App/Sqitch/ItemFormatter.pm:216
 #, perl-brace-format
 msgid "Unknown format code \"{code}\""
-msgstr ""
+msgstr "Formato codice \"{code}\" sconosciuto"
 
 #: lib/App/Sqitch/Plan.pm:130
 #, perl-brace-format
 msgid "Plan file {file} does not exist"
-msgstr ""
+msgstr "File di piano {file} inesistente"
 
 #: lib/App/Sqitch/Plan.pm:132
 #, perl-brace-format
 msgid "Plan file {file} is not a regular file"
-msgstr ""
+msgstr "Il file di piano {file} non è un file regolare"
 
 #: lib/App/Sqitch/Plan.pm:183
 #, perl-brace-format
 msgid "Syntax error in {file} at line {lineno}: {error}"
-msgstr ""
+msgstr "Errore di sintassi nel file {file} alla linea {lineno}: {error}"
 
 #: lib/App/Sqitch/Plan.pm:207
 msgid "Invalid pragma; a blank line must come between pragmas and changes"
 msgstr ""
+"Pragma non valido; una linea vuota deve trovarsi fra ogni pragma e ogni "
+"modifica"
 
 #: lib/App/Sqitch/Plan.pm:264
 #, perl-format, perl-brace-format
 msgid "Missing %project pragma in {file}"
-msgstr ""
+msgstr "Pragma %project mancante in {file}"
 
 #: lib/App/Sqitch/Plan.pm:319
 msgid ""
 "Invalid name; names must not begin with punctuation, contain \"@\", \":\", "
 "\"#\", or blanks, or end in punctuation or digits following punctuation"
 msgstr ""
+"Nome non valido; i nomi non devono cominciare con caratteri di "
+"punteggiatura, contenere  \"@\", \":\", \"#\" o spazi, o finire in caratteri "
+"di punteggiature e cifre numeriche dopo la punteggiatura."
 
 #: lib/App/Sqitch/Plan.pm:324
 msgid "Missing timestamp and planner name and email"
-msgstr ""
+msgstr "Timestamp, nome dell'esecutore e email mancanti"
 
 #: lib/App/Sqitch/Plan.pm:326
 msgid "Missing timestamp"
-msgstr ""
+msgstr "Timestamp mancante"
 
 #: lib/App/Sqitch/Plan.pm:328
 msgid "Missing planner name and email"
-msgstr ""
+msgstr "Nome dell'esecutore ed email mancanti"
 
 #: lib/App/Sqitch/Plan.pm:333 lib/App/Sqitch/Plan.pm:894
 #, perl-brace-format
 msgid "\"{name}\" is a reserved name"
-msgstr ""
+msgstr "\"{name}\" è un nome riservato"
 
 #: lib/App/Sqitch/Plan.pm:339 lib/App/Sqitch/Plan.pm:898
 #, perl-brace-format
 msgid "\"{name}\" is invalid because it could be confused with a SHA1 ID"
 msgstr ""
+"\"{name}\" non è valido perché potrebbe essere confuso con un hash SHA1"
 
 #: lib/App/Sqitch/Plan.pm:359
 #, perl-brace-format
 msgid "Tag \"{tag}\" declared without a preceding change"
-msgstr ""
+msgstr "Il tag \"{tag}\" è stato dichiarato senza una modifica che lo precede"
 
 #: lib/App/Sqitch/Plan.pm:368
 #, perl-brace-format
 msgid "Tag \"{tag}\" duplicates earlier declaration on line {line}"
-msgstr ""
+msgstr "Il tag \"{tag}\" è duplicato e già presente alla linea {line}"
 
 #: lib/App/Sqitch/Plan.pm:376
 msgid "Tags may not specify dependencies"
-msgstr ""
+msgstr "I tag non possono specificare delle dipendenze"
 
 #: lib/App/Sqitch/Plan.pm:405
 #, perl-brace-format
 msgid "Change \"{change}\" duplicates earlier declaration on line {line}"
-msgstr ""
+msgstr "La modifica \"{change}\" risulta duplicata alla linea {line}"
 
 #: lib/App/Sqitch/Plan.pm:418 lib/App/Sqitch/Plan.pm:766
 #: lib/App/Sqitch/Plan.pm:778
 #, perl-brace-format
 msgid "\"{dep}\" is not a valid dependency specification"
-msgstr ""
+msgstr "\"{dep}\" non è una dichiarazione di dependenza valida"
 
 #: lib/App/Sqitch/Plan.pm:536
 #, perl-brace-format
 msgid "Change \"{change}\" cannot require itself"
-msgstr ""
+msgstr "La modifica \"{change}\" non può richiedere se stessa"
 
 #: lib/App/Sqitch/Plan.pm:543
 #, perl-brace-format


### PR DESCRIPTION
This is a first attempt to localize the program to the italian language.

The translation has been edited with `poedit`.
I strongly encourage a review by another italian speaker before applying this PR.

There are some terms that have not been traslated to italian:
- target
- deploy
- commit
- committer
- tag

Others have been translated to something that should make sense:
- change => modifica
- by => autore
- note => commento
- engine => motore
- rebase => annullo/ritorno
- rework => rilavorazione/riesecuzione
- label => etichetta
