### PR TITLE
Exit 0 for rebase and revert unless unsuccessful

### DIFF
--- a/Changes
+++ b/Changes
@@ -23,6 +23,10 @@ Revision history for Perl extension App::Sqitch
      - Added the Exasol engine. Thanks to Johan Wärlander for the PR (#362)!
      - Fixed and issue where URI::db needed to be explicitly loaded. Thanks to
        Hugh Esco for the report (#370)!
+     - Changed the exit value for rebase and revert from 1 to 0 when there is
+       no work to do. This is to match a shell's expectation of non-zero exit
+       statuses only when a command is unsuccessful. Nothing to do is considered
+       successful (#363).
 
 0.9996 2017-07-17T18:33:12Z
      - Fixed an error where Oracle sometimes truncated timestamp formats so

--- a/lib/App/Sqitch/Engine.pm
+++ b/lib/App/Sqitch/Engine.pm
@@ -260,13 +260,12 @@ sub revert {
 
         @changes = $self->deployed_changes_since(
             $self->_load_changes($change)
-        ) or hurl {
-            ident => 'revert',
-            message => __x(
+        ) or do {
+            $sqitch->info(__x(
                 'No changes deployed since: "{change}"',
                 change => $to,
-            ),
-            exitval => 1,
+            ));
+            return $self;
         };
 
         if ($self->no_prompt) {
@@ -288,10 +287,9 @@ sub revert {
         }
 
     } else {
-        @changes = $self->deployed_changes or hurl {
-            ident   => 'revert',
-            message => __ 'Nothing to revert (nothing deployed)',
-            exitval => 1,
+        @changes = $self->deployed_changes or do {
+            $sqitch->info(__ 'Nothing to revert (nothing deployed)');
+            return $self;
         };
 
         if ($self->no_prompt) {
@@ -335,21 +333,17 @@ sub verify {
     my $plan     = $self->plan;
     my @changes  = $self->_load_changes( $self->deployed_changes );
 
-    $self->sqitch->info(__x(
+    $sqitch->info(__x(
         'Verifying {destination}',
         destination => $self->destination,
     ));
 
     if (!@changes) {
-        # Probably expected, but exit 1 anyway.
         my $msg = $plan->count
             ? __ 'No changes deployed'
             : __ 'Nothing to verify (no planned or deployed changes)';
-        hurl {
-            ident   => 'verify',
-            message => $msg,
-            exitval => 1,
-        };
+        $sqitch->info($msg);
+        return $self;
     }
 
     if ($plan->count == 0) {


### PR DESCRIPTION
Changed the exit value for rebase and revert from 1 to 0 when there is
no work to do. This is to match a shell's expectation of non-zero exit
statuses only when a command is unsuccessful. Nothing to do is
considered successful.

Closes #363.