### PR TITLE
Update Debian installation instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@ from your typical <a href="http://guides.rubyonrails.org/migrations.html">migrat
   <li>Vertica: <code>brew install sqitch_vertica</code></li>
 </ul>
 
-<h4 id="debian"><a href="https://www.debian.org/releases/sid/">Debian sid</a> (unstable, testing)</h4>
+<h4 id="debian"><a href="https://www.debian.org/">Debian</a></h4>
 
 <ul>
   <li>Apt: <code>apt-get install sqitch</code></li>
@@ -92,8 +92,9 @@ from your typical <a href="http://guides.rubyonrails.org/migrations.html">migrat
   <li>SQLite: <code>apt-get install libdbd-sqlite3-perl sqlite3</code></li>
   <li>Oracle: <code>apt-get install libdbd-oracle-perl</code></li>
   <li>MySQL: <code>apt-get install libdbd-mysql-perl mysql-client</code></li>
-  <li>Firebird Classic: <code>apt-get install libdbd-firebird-perl firebird2.5-classic</code></li>
-  <li>Firebird Super: <code>apt-get install libdbd-firebird-perl firebird2.5-super</code></li>
+  <li>Firebird 3.0 (Debian 9 and later): <code>apt-get install libdbd-firebird-perl firebird3.0-utils</code></li>
+  <li>Firebird Classic (Debian 8 and earlier): <code>apt-get install libdbd-firebird-perl firebird2.5-classic</code></li>
+  <li>Firebird Super (Debian 8 and earlier): <code>apt-get install libdbd-firebird-perl firebird2.5-super</code></li>
   <li>Vertica: <code>apt-get install libdbd-odbc-perl</code></li>
 </ul>
 


### PR DESCRIPTION
- Sqitch has been included in Debian since 8, no need to specify sid/testing/unstable
- Debian 9 ships Firebird 3.0, which has a separate client package (but keep the instructions for 8 and earlier)