### PR TITLE
Update dictionaries and prep v1.5.2

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,12 +1,14 @@
 Revision history for Perl extension App::Sqitch
 
-1.5.2  Not yet released
+1.5.2  2025-04-29T15:13:35Z
+     - Added missing German translations, thanks to @0xflotus for the PR
+       (#873)!
      - Fixed bug where the location of reworked script files did not respect
        the `deploy_dir`, `revert_dir`, or `verify_dir` options. Thanks to Neil
        Freeman for the report (#875)!
      - Updated the MySQL engine's installation of the `checkit()` function so
        that it no longer depends on permission-checking, since the current
-       user may not have such permission, and instead attempts to create the
+       user may not have such permission. It instead attempts to create the
        function and ignores a failure due to a lack of permission. Thanks to
        Alastair Douglas for the report and solution (#874)!
      - Added missing CockroachDB templates. Thanks to @Peterbyte for the
@@ -14,11 +16,11 @@ Revision history for Perl extension App::Sqitch
      - Removed support for the `SNOWSQL_PORT` environment variable, which has
        long been deprecated by Snowflake and likely never did anything.
      - Fixed the quoting of the role and schema names on connecting to
-       Snowflake, which was silently failing and thus failing to properly use
-       the registry schema, which lead to a failure to find the registry.
-       Broken in v1.5.1.
+       Snowflake, which was silently failing and thus not properly using the
+       registry schema, which lead to a failure to find the registry. Broken
+       in v1.5.1.
      - Added redaction of passwords from Snowflake URL query parameters in the
-       display URL. Any query parameter matching `pwd` will now be shown as
+       display URL. Any query parameter matching `pwd` will now appear as
        "REDACTED".
      - Expanded the documentation of Snowflake key pair authentication in
       `sqitch-authentication.pod` to recommend setting sensitive ODBC

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-App/Sqitch version v1.5.2-dev
+App/Sqitch version v1.5.2
 =========================
 
 | Release           | Coverage          | Database                              ||

--- a/dist/sqitch.spec
+++ b/dist/sqitch.spec
@@ -1,5 +1,5 @@
 Name:           sqitch
-Version:        1.5.2-dev
+Version:        1.5.2
 Release:        1%{?dist}
 Summary:        Sensible database change management
 License:        MIT
@@ -309,6 +309,9 @@ also be installed.
 # No additional files required.
 
 %changelog
+* Mon Apr 29 2025 David E. Wheeler <david@justatheory.com> 1.5.2-1
+- Upgrade to v1.5.2.
+
 * Sun Mar 16 2025 David E. Wheeler <david@justatheory.com> 1.5.1-1
 - Upgrade to v1.5.1.
 

--- a/po/App-Sqitch.pot
+++ b/po/App-Sqitch.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: App-Sqitch v1.5.2-dev\n"
+"Project-Id-Version: App-Sqitch v1.5.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-18 18:18-0500\n"
+"POT-Creation-Date: 2025-04-27 19:42-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -147,7 +147,7 @@ msgid "Skipped {file}: already exists"
 msgstr ""
 
 #: lib/App/Sqitch/Command/add.pm:386 lib/App/Sqitch/Command/add.pm:427
-#: lib/App/Sqitch/Engine/snowflake.pm:330 lib/App/Sqitch/Plan.pm:136
+#: lib/App/Sqitch/Engine/snowflake.pm:331 lib/App/Sqitch/Plan.pm:136
 #: lib/App/Sqitch/Plan.pm:602 lib/App/Sqitch/Plan.pm:982
 #: lib/App/Sqitch/Plan/Line.pm:107
 #: lib/App/Sqitch/Role/TargetConfigCommand.pm:321
@@ -658,7 +658,7 @@ msgid "Unknown date format \"{format}\""
 msgstr ""
 
 #: lib/App/Sqitch/Engine.pm:168 lib/App/Sqitch/Engine.pm:183
-#: lib/App/Sqitch/Role/TargetConfigCommand.pm:162 lib/App/Sqitch/Target.pm:251
+#: lib/App/Sqitch/Role/TargetConfigCommand.pm:162 lib/App/Sqitch/Target.pm:254
 msgid "No engine specified; specify via target or core.engine"
 msgstr ""
 
@@ -1075,11 +1075,11 @@ msgstr ""
 msgid "Database name missing in URI \"{uri}\""
 msgstr ""
 
-#: lib/App/Sqitch/Engine/mysql.pm:489
+#: lib/App/Sqitch/Engine/mysql.pm:518
 msgid "Insufficient permissions to create the checkit() function; skipping."
 msgstr ""
 
-#: lib/App/Sqitch/Engine/pg.pm:202 lib/App/Sqitch/Engine/snowflake.pm:297
+#: lib/App/Sqitch/Engine/pg.pm:202 lib/App/Sqitch/Engine/snowflake.pm:298
 #: lib/App/Sqitch/Engine/vertica.pm:137
 #, perl-brace-format
 msgid "Sqitch schema \"{schema}\" already exists"
@@ -1095,7 +1095,7 @@ msgid ""
 "database to create its registry tables."
 msgstr ""
 
-#: lib/App/Sqitch/Engine/snowflake.pm:121
+#: lib/App/Sqitch/Engine/snowflake.pm:120
 msgid "Cannot determine Snowflake account name"
 msgstr ""
 
@@ -1511,23 +1511,23 @@ msgid ""
 "Cannot initialize because project \"{project}\" already initialized in {file}"
 msgstr ""
 
-#: lib/App/Sqitch/Target.pm:254
+#: lib/App/Sqitch/Target.pm:257
 msgid ""
 "No project configuration found. Run the \"init\" command to initialize a "
 "project"
 msgstr ""
 
-#: lib/App/Sqitch/Target.pm:276
+#: lib/App/Sqitch/Target.pm:279
 #, perl-brace-format
 msgid "Cannot find target \"{target}\""
 msgstr ""
 
-#: lib/App/Sqitch/Target.pm:282
+#: lib/App/Sqitch/Target.pm:285
 #, perl-brace-format
 msgid "No URI associated with target \"{target}\""
 msgstr ""
 
-#: lib/App/Sqitch/Target.pm:291
+#: lib/App/Sqitch/Target.pm:294
 #, perl-brace-format
 msgid "No engine specified by URI {uri}; URI must start with \"db:$engine:\""
 msgstr ""

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Sqitch 0.932\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-04 14:21-0500\n"
+"POT-Creation-Date: 2025-04-27 19:42-0400\n"
 "PO-Revision-Date: 2012-08-31 17:15-0700\n"
 "Last-Translator: Thomas Iguchi <ti@nobu-games.com>\n"
 "Language-Team: Sqitch Hackers <sqitch-hackers@googlegroups.com>\n"
@@ -157,7 +157,7 @@ msgid "Skipped {file}: already exists"
 msgstr "Überspringe {file}: existiert bereits"
 
 #: lib/App/Sqitch/Command/add.pm:386 lib/App/Sqitch/Command/add.pm:427
-#: lib/App/Sqitch/Engine/snowflake.pm:330 lib/App/Sqitch/Plan.pm:136
+#: lib/App/Sqitch/Engine/snowflake.pm:331 lib/App/Sqitch/Plan.pm:136
 #: lib/App/Sqitch/Plan.pm:602 lib/App/Sqitch/Plan.pm:982
 #: lib/App/Sqitch/Plan/Line.pm:107
 #: lib/App/Sqitch/Role/TargetConfigCommand.pm:321
@@ -697,7 +697,7 @@ msgid "Unknown date format \"{format}\""
 msgstr "Unbekanntes Datumsformat \"{format}\""
 
 #: lib/App/Sqitch/Engine.pm:168 lib/App/Sqitch/Engine.pm:183
-#: lib/App/Sqitch/Role/TargetConfigCommand.pm:162 lib/App/Sqitch/Target.pm:251
+#: lib/App/Sqitch/Role/TargetConfigCommand.pm:162 lib/App/Sqitch/Target.pm:254
 msgid "No engine specified; specify via target or core.engine"
 msgstr ""
 "Keine Engine angegeben. Bitte gib eine via \"target\" oder \"core.engine\" an"
@@ -975,14 +975,18 @@ msgstr "Verifizierungsskript {file} existiert nicht"
 msgid ""
 "Blocked by another instance of Sqitch working on {dest}; waiting {secs} "
 "seconds..."
-msgstr "Geblockt von einer anderen Sqitch Instanz auf {dest}; Warte {secs} Sekunden..."
+msgstr ""
+"Geblockt von einer anderen Sqitch Instanz auf {dest}; Warte {secs} "
+"Sekunden..."
 
 #: lib/App/Sqitch/Engine.pm:1135
 #, perl-brace-format
 msgid ""
 "Timed out waiting {secs} seconds for another instance of Sqitch to finish "
 "work on {dest}"
-msgstr "Zeit nach {secs} Sekunden abgelaufen um auf eine andere Sqitch Instanz auf {dest} zu warten."
+msgstr ""
+"Zeit nach {secs} Sekunden abgelaufen um auf eine andere Sqitch Instanz auf "
+"{dest} zu warten."
 
 #: lib/App/Sqitch/Engine.pm:1194
 #, perl-brace-format
@@ -1139,11 +1143,12 @@ msgstr ""
 msgid "Database name missing in URI \"{uri}\""
 msgstr "Name der Datenbank fehlt in URI \"{uri}\""
 
-#: lib/App/Sqitch/Engine/mysql.pm:489
+#: lib/App/Sqitch/Engine/mysql.pm:518
 msgid "Insufficient permissions to create the checkit() function; skipping."
-msgstr "Unzureichende Berechtigung um checkit() Funktion zu erstellen; Überspringe."
+msgstr ""
+"Unzureichende Berechtigung um checkit() Funktion zu erstellen; Überspringe."
 
-#: lib/App/Sqitch/Engine/pg.pm:202 lib/App/Sqitch/Engine/snowflake.pm:297
+#: lib/App/Sqitch/Engine/pg.pm:202 lib/App/Sqitch/Engine/snowflake.pm:298
 #: lib/App/Sqitch/Engine/vertica.pm:137
 #, perl-brace-format
 msgid "Sqitch schema \"{schema}\" already exists"
@@ -1158,10 +1163,11 @@ msgstr "Sqitch ist bereits initialisiert"
 msgid ""
 "Because the \"changes\" table does not exist, Sqitch will now initialize the "
 "database to create its registry tables."
-msgstr "Weil die \"changes\" Tabelle nicht existiert, wird Sqitch jetzt die Datenbank "
-"initialisieren um die Registry Tabellen zu erstellen."
+msgstr ""
+"Weil die \"changes\" Tabelle nicht existiert, wird Sqitch jetzt die "
+"Datenbank initialisieren um die Registry Tabellen zu erstellen."
 
-#: lib/App/Sqitch/Engine/snowflake.pm:121
+#: lib/App/Sqitch/Engine/snowflake.pm:120
 msgid "Cannot determine Snowflake account name"
 msgstr "Kann Namen für Snowflake-Benutzerkonto nicht herausfinden"
 
@@ -1585,8 +1591,9 @@ msgstr ""
 msgid ""
 "\"{command}\" cannot be used in strict mode.\\nUse explicity revert and "
 "deploy commands instead."
-msgstr "\"{command}\” kann im strikten Modus nicht verwendet werden.\\n "
-"Verwende Revert und Deploy Kommandos explizit."
+msgstr ""
+"\"{command}\" kann im strikten Modus nicht verwendet werden.\\n Verwende "
+"Revert und Deploy Kommandos explizit."
 
 #: lib/App/Sqitch/Role/TargetConfigCommand.pm:96
 #, perl-brace-format
@@ -1633,7 +1640,7 @@ msgstr ""
 "Kann nicht initialisieren da Projekt \"{project}\" bereits in {file} "
 "initialisiert wurde"
 
-#: lib/App/Sqitch/Target.pm:254
+#: lib/App/Sqitch/Target.pm:257
 msgid ""
 "No project configuration found. Run the \"init\" command to initialize a "
 "project"
@@ -1641,17 +1648,17 @@ msgstr ""
 "Fehlende Projektkonfiguration. Bitte führe den \"init\"-Befehl aus, um das "
 "Projekt zu initialisieren"
 
-#: lib/App/Sqitch/Target.pm:276
+#: lib/App/Sqitch/Target.pm:279
 #, perl-brace-format
 msgid "Cannot find target \"{target}\""
 msgstr "Kann Ziel \"{target}\" nicht finden"
 
-#: lib/App/Sqitch/Target.pm:282
+#: lib/App/Sqitch/Target.pm:285
 #, perl-brace-format
 msgid "No URI associated with target \"{target}\""
 msgstr "Keine URI mit Ziel \"{target}\" verknüpft"
 
-#: lib/App/Sqitch/Target.pm:291
+#: lib/App/Sqitch/Target.pm:294
 #, perl-brace-format
 msgid "No engine specified by URI {uri}; URI must start with \"db:$engine:\""
 msgstr ""

--- a/po/fr_FR.po
+++ b/po/fr_FR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Sqitch 0.932\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-04 14:21-0500\n"
+"POT-Creation-Date: 2025-04-27 19:42-0400\n"
 "PO-Revision-Date: 2012-10-12 11:28-0700\n"
 "Last-Translator: Arnaud Assad <arhuman@gmail.com>\n"
 "Language-Team: Sqitch Hackers <sqitch-hackers@googlegroups.com>\n"
@@ -150,7 +150,7 @@ msgid "Skipped {file}: already exists"
 msgstr "Ignoré {file}: existe déjà"
 
 #: lib/App/Sqitch/Command/add.pm:386 lib/App/Sqitch/Command/add.pm:427
-#: lib/App/Sqitch/Engine/snowflake.pm:330 lib/App/Sqitch/Plan.pm:136
+#: lib/App/Sqitch/Engine/snowflake.pm:331 lib/App/Sqitch/Plan.pm:136
 #: lib/App/Sqitch/Plan.pm:602 lib/App/Sqitch/Plan.pm:982
 #: lib/App/Sqitch/Plan/Line.pm:107
 #: lib/App/Sqitch/Role/TargetConfigCommand.pm:321
@@ -671,7 +671,7 @@ msgid "Unknown date format \"{format}\""
 msgstr "Format de date inconnu \"{format}\""
 
 #: lib/App/Sqitch/Engine.pm:168 lib/App/Sqitch/Engine.pm:183
-#: lib/App/Sqitch/Role/TargetConfigCommand.pm:162 lib/App/Sqitch/Target.pm:251
+#: lib/App/Sqitch/Role/TargetConfigCommand.pm:162 lib/App/Sqitch/Target.pm:254
 #, fuzzy
 msgid "No engine specified; specify via target or core.engine"
 msgstr "Pas de moteur spécifié; utiliser --engine ou définir core.engine"
@@ -1101,11 +1101,11 @@ msgstr ""
 msgid "Database name missing in URI \"{uri}\""
 msgstr ""
 
-#: lib/App/Sqitch/Engine/mysql.pm:489
+#: lib/App/Sqitch/Engine/mysql.pm:518
 msgid "Insufficient permissions to create the checkit() function; skipping."
 msgstr ""
 
-#: lib/App/Sqitch/Engine/pg.pm:202 lib/App/Sqitch/Engine/snowflake.pm:297
+#: lib/App/Sqitch/Engine/pg.pm:202 lib/App/Sqitch/Engine/snowflake.pm:298
 #: lib/App/Sqitch/Engine/vertica.pm:137
 #, perl-brace-format
 msgid "Sqitch schema \"{schema}\" already exists"
@@ -1121,7 +1121,7 @@ msgid ""
 "database to create its registry tables."
 msgstr ""
 
-#: lib/App/Sqitch/Engine/snowflake.pm:121
+#: lib/App/Sqitch/Engine/snowflake.pm:120
 msgid "Cannot determine Snowflake account name"
 msgstr ""
 
@@ -1582,23 +1582,23 @@ msgid ""
 "Cannot initialize because project \"{project}\" already initialized in {file}"
 msgstr ""
 
-#: lib/App/Sqitch/Target.pm:254
+#: lib/App/Sqitch/Target.pm:257
 msgid ""
 "No project configuration found. Run the \"init\" command to initialize a "
 "project"
 msgstr ""
 
-#: lib/App/Sqitch/Target.pm:276
+#: lib/App/Sqitch/Target.pm:279
 #, fuzzy, perl-brace-format
 msgid "Cannot find target \"{target}\""
 msgstr "Impossible de trouver le changement {change}"
 
-#: lib/App/Sqitch/Target.pm:282
+#: lib/App/Sqitch/Target.pm:285
 #, fuzzy, perl-brace-format
 msgid "No URI associated with target \"{target}\""
 msgstr "Cible d'annulation inconnue : \"{target}\""
 
-#: lib/App/Sqitch/Target.pm:291
+#: lib/App/Sqitch/Target.pm:294
 #, perl-brace-format
 msgid "No engine specified by URI {uri}; URI must start with \"db:$engine:\""
 msgstr ""

--- a/po/it_IT.po
+++ b/po/it_IT.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: App-Sqitch 0.9996\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-04 14:21-0500\n"
+"POT-Creation-Date: 2025-04-27 19:42-0400\n"
 "PO-Revision-Date: 2017-10-12 10:30+0200\n"
 "Last-Translator: Luca Ferrari <fluca1978@gmail.com>\n"
 "Language-Team: Sqitch Hackers <sqitch-hackers@googlegroups.com>\n"
@@ -155,7 +155,7 @@ msgid "Skipped {file}: already exists"
 msgstr "Saltato {file}: esiste già"
 
 #: lib/App/Sqitch/Command/add.pm:386 lib/App/Sqitch/Command/add.pm:427
-#: lib/App/Sqitch/Engine/snowflake.pm:330 lib/App/Sqitch/Plan.pm:136
+#: lib/App/Sqitch/Engine/snowflake.pm:331 lib/App/Sqitch/Plan.pm:136
 #: lib/App/Sqitch/Plan.pm:602 lib/App/Sqitch/Plan.pm:982
 #: lib/App/Sqitch/Plan/Line.pm:107
 #: lib/App/Sqitch/Role/TargetConfigCommand.pm:321
@@ -683,7 +683,7 @@ msgid "Unknown date format \"{format}\""
 msgstr "Formato data \"{format}\" sconosciuto"
 
 #: lib/App/Sqitch/Engine.pm:168 lib/App/Sqitch/Engine.pm:183
-#: lib/App/Sqitch/Role/TargetConfigCommand.pm:162 lib/App/Sqitch/Target.pm:251
+#: lib/App/Sqitch/Role/TargetConfigCommand.pm:162 lib/App/Sqitch/Target.pm:254
 #, fuzzy
 msgid "No engine specified; specify via target or core.engine"
 msgstr "Nessun motore specificato: usa --engine o imposta core.engine"
@@ -1124,11 +1124,11 @@ msgstr ""
 msgid "Database name missing in URI \"{uri}\""
 msgstr "Il nome di database non è specificato nell'URI {uri}"
 
-#: lib/App/Sqitch/Engine/mysql.pm:489
+#: lib/App/Sqitch/Engine/mysql.pm:518
 msgid "Insufficient permissions to create the checkit() function; skipping."
 msgstr ""
 
-#: lib/App/Sqitch/Engine/pg.pm:202 lib/App/Sqitch/Engine/snowflake.pm:297
+#: lib/App/Sqitch/Engine/pg.pm:202 lib/App/Sqitch/Engine/snowflake.pm:298
 #: lib/App/Sqitch/Engine/vertica.pm:137
 #, perl-brace-format
 msgid "Sqitch schema \"{schema}\" already exists"
@@ -1145,7 +1145,7 @@ msgid ""
 "database to create its registry tables."
 msgstr ""
 
-#: lib/App/Sqitch/Engine/snowflake.pm:121
+#: lib/App/Sqitch/Engine/snowflake.pm:120
 msgid "Cannot determine Snowflake account name"
 msgstr ""
 
@@ -1617,23 +1617,23 @@ msgstr ""
 "Impossibile inizializzare poiché il progetto \"{project}\" è già stato "
 "inizializzato in {file}"
 
-#: lib/App/Sqitch/Target.pm:254
+#: lib/App/Sqitch/Target.pm:257
 msgid ""
 "No project configuration found. Run the \"init\" command to initialize a "
 "project"
 msgstr ""
 
-#: lib/App/Sqitch/Target.pm:276
+#: lib/App/Sqitch/Target.pm:279
 #, perl-brace-format
 msgid "Cannot find target \"{target}\""
 msgstr "Non posso trovare il target specificato \"{target}\""
 
-#: lib/App/Sqitch/Target.pm:282
+#: lib/App/Sqitch/Target.pm:285
 #, perl-brace-format
 msgid "No URI associated with target \"{target}\""
 msgstr "Nessun URI associato al target \"{target}\""
 
-#: lib/App/Sqitch/Target.pm:291
+#: lib/App/Sqitch/Target.pm:294
 #, perl-brace-format
 msgid "No engine specified by URI {uri}; URI must start with \"db:$engine:\""
 msgstr ""

--- a/t/engine.t
+++ b/t/engine.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 use utf8;
-use Test::More tests => 794;
+use Test::More tests => 802;
 # use Test::More 'no_plan';
 use App::Sqitch;
 use App::Sqitch::Plan;
@@ -35,7 +35,7 @@ BEGIN {
     delete $ENV{USER};
 }
 
-can_ok $CLASS, qw(load new name run_deploy run_revert run_verify uri);
+can_ok $CLASS, qw(load new name run_deploy run_revert run_verify run_upgrade uri);
 
 my ($is_deployed_tag, $is_deployed_change) = (0, 0);
 my @deployed_changes;
@@ -162,7 +162,7 @@ throws_ok { $CLASS->load({ sqitch => $sqitch, target => $unknown_target }) }
 is $@->message, __x('Unknown engine: {engine}', engine =>  'nonexistent'),
     'Should get load error message';
 like $@->previous_exception, qr/\QCan't locate/,
-    'Should have relevant previoius exception';
+    'Should have relevant previous exception';
 
 NOENGINE: {
     # Test handling of no target.
@@ -183,7 +183,22 @@ throws_ok { $CLASS->load({ sqitch => $sqitch, target => $bad_target }) }
 is $@->message, __x('Unknown engine: {engine}', engine =>  'bad'),
     'Should get another load error message';
 like $@->previous_exception, qr/^LOL BADZ/,
-    'Should have relevant previoius exception from the bad module';
+    'Should have relevant previous exception from the bad module';
+
+##############################################################################
+# Test run methods.
+ok $engine->run_deploy('deploy');
+is_deeply $engine->seen, [[qw(run_file deploy)]],
+    'run_deploy have called run_file';
+ok $engine->run_revert('revert');
+is_deeply $engine->seen, [[qw(run_file revert)]],
+    'run_revert have called run_file';
+ok $engine->run_verify('verify');
+is_deeply $engine->seen, [[qw(run_file verify)]],
+    'run_verify have called run_file';
+ok $engine->run_upgrade('upgrade');
+is_deeply $engine->seen, [[qw(run_file upgrade)]],
+    'run_upgrade have called run_file';
 
 ##############################################################################
 # Test name.

--- a/xt/dependency_report
+++ b/xt/dependency_report
@@ -28,7 +28,10 @@ $api_uri = s/^https:/http:/ if $@;
 sub new {
     my $class = shift;
     return bless {
-        dist_for => {},
+        dist_for => {
+            # No API for Config.pm, so record it as part of Perl core here.
+            Config => { distribution => 'perl' },
+        },
         http     => HTTP::Tiny->new(agent => __PACKAGE__ . "/$VERSION"),
         tree     => 1,
         report   => 1,

--- a/xt/release.md
+++ b/xt/release.md
@@ -6,9 +6,9 @@ use the `$VERSION` and `$OLD_VERSION` environment variables for consistency. The
 assumption is that they're set to the old and new versions, respectively, e.g.,
 
 ``` sh
-export OLD_VERSION=1.5.0
-export VERSION=1.5.1
-export NEXT_VERSION=1.5.2
+export OLD_VERSION=1.5.1
+export VERSION=1.5.2
+export NEXT_VERSION=1.5.3
 ```
 
 Preparation


### PR DESCRIPTION
Also add missing test coverage for Engine::run_deploy by testing the default implementation of all the run_* methods.
