### PR TITLE
Move unmocking till after done testing `$@`

### DIFF
--- a/.github/workflows/clickhouse.yml
+++ b/.github/workflows/clickhouse.yml
@@ -37,8 +37,8 @@ jobs:
         with:
           path: local
           key: perl-${{ steps.perl.outputs.perl-hash }}
-      - run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends --cpanfile dist/cpanfile
-      - run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends DBD::ODBC
+      - run: cpm install --top-level-phase configure,build,test,runtime --verbose --show-build-log-on-failure --no-test --top-level-relationship requires,recommends --cpanfile dist/cpanfile
+      - run: cpm install --top-level-phase configure,build,test,runtime --verbose --show-build-log-on-failure --no-test --top-level-relationship requires,recommends DBD::ODBC
       - name: prove
         env:
           PERL5LIB: "${{ github.workspace }}/local/lib/perl5"

--- a/.github/workflows/cockroach.yml
+++ b/.github/workflows/cockroach.yml
@@ -9,9 +9,10 @@ on:
 jobs:
   Cockroach:
     strategy:
+      fail-fast: false
       matrix:
         # curl https://registry.hub.docker.com/v2/repositories/cockroachdb/cockroach/tags\?page_size\=10000 | jq '.results[].name'
-        version: ['25.4', '24.3', '23.2', '22.2', '21.2']
+        version: ['26.2', '25.4', '24.3', '23.2']
     name: 🪳 Cockroach ${{ matrix.version }}
     runs-on: ubuntu-latest
     steps:
@@ -27,8 +28,8 @@ jobs:
         with:
           path: local
           key: perl-${{ steps.perl.outputs.perl-hash }}
-      - run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends --cpanfile dist/cpanfile
-      - run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends DBD::Pg
+      - run: cpm install --top-level-phase configure,build,test,runtime --verbose --show-build-log-on-failure --no-test --top-level-relationship requires,recommends --cpanfile dist/cpanfile
+      - run: cpm install --top-level-phase configure,build,test,runtime --verbose --show-build-log-on-failure --no-test --top-level-relationship requires,recommends DBD::Pg
       - name: prove
         env:
           PERL5LIB: "${{ github.workspace }}/local/lib/perl5"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -86,8 +86,8 @@ jobs:
           .github/ubuntu/pg.sh
           .github/ubuntu/snowflake.sh
           .github/ubuntu/vertica.sh
-      - run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends --cpanfile dist/cpanfile
-      - run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends DBI DBD::ODBC DBD::Firebird DBD::Oracle DBD::MariaDB DBD::Pg Devel::Cover Devel::Cover::Report::Coveralls
+      - run: cpm install --top-level-phase configure,build,test,runtime --verbose --show-build-log-on-failure --no-test --top-level-relationship requires,recommends --cpanfile dist/cpanfile
+      - run: cpm install --top-level-phase configure,build,test,runtime --verbose --show-build-log-on-failure --no-test --top-level-relationship requires,recommends DBI DBD::ODBC DBD::Firebird DBD::Oracle DBD::MariaDB DBD::Pg Devel::Cover Devel::Cover::Report::Coveralls
       - name: Run Tests
         env:
           PERL5LIB: "${{ github.workspace }}/local/lib/perl5"

--- a/.github/workflows/exasol.yml
+++ b/.github/workflows/exasol.yml
@@ -31,8 +31,8 @@ jobs:
         with:
           path: local
           key: perl-${{ steps.perl.outputs.perl-hash }}
-      - run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends --cpanfile dist/cpanfile
-      - run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends DBD::ODBC
+      - run: cpm install --top-level-phase configure,build,test,runtime --verbose --show-build-log-on-failure --no-test --top-level-relationship requires,recommends --cpanfile dist/cpanfile
+      - run: cpm install --top-level-phase configure,build,test,runtime --verbose --show-build-log-on-failure --no-test --top-level-relationship requires,recommends DBD::ODBC
       - name: prove
         env:
           PERL5LIB: "${{ github.workspace }}/local/lib/perl5"

--- a/.github/workflows/firebird.yml
+++ b/.github/workflows/firebird.yml
@@ -42,8 +42,8 @@ jobs:
         with:
           path: local
           key: perl-${{ steps.perl.outputs.perl-hash }}
-      - run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends --cpanfile dist/cpanfile
-      - run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends DBD::Firebird
+      - run: cpm install --top-level-phase configure,build,test,runtime --verbose --show-build-log-on-failure --no-test --top-level-relationship requires,recommends --cpanfile dist/cpanfile
+      - run: cpm install --top-level-phase configure,build,test,runtime --verbose --show-build-log-on-failure --no-test --top-level-relationship requires,recommends DBD::Firebird
       - name: prove
         env:
           PERL5LIB: "${{ github.workspace }}/local/lib/perl5"

--- a/.github/workflows/maria.yml
+++ b/.github/workflows/maria.yml
@@ -36,8 +36,8 @@ jobs:
         with:
           path: local
           key: perl-${{ steps.perl.outputs.perl-hash }}
-      - run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends --cpanfile dist/cpanfile
-      - run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends DBD::MariaDB
+      - run: cpm install --top-level-phase configure,build,test,runtime --verbose --show-build-log-on-failure --no-test --top-level-relationship requires,recommends --cpanfile dist/cpanfile
+      - run: cpm install --top-level-phase configure,build,test,runtime --verbose --show-build-log-on-failure --no-test --top-level-relationship requires,recommends DBD::MariaDB
       - name: prove
         env:
           PERL5LIB: "${{ github.workspace }}/local/lib/perl5"

--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -36,8 +36,8 @@ jobs:
         with:
           path: local
           key: perl-${{ steps.perl.outputs.perl-hash }}
-      - run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends --cpanfile dist/cpanfile
-      - run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends DBD::MariaDB
+      - run: cpm install --top-level-phase configure,build,test,runtime --verbose --show-build-log-on-failure --no-test --top-level-relationship requires,recommends --cpanfile dist/cpanfile
+      - run: cpm install --top-level-phase configure,build,test,runtime --verbose --show-build-log-on-failure --no-test --top-level-relationship requires,recommends DBD::MariaDB
       - name: prove
         env:
           PERL5LIB: "${{ github.workspace }}/local/lib/perl5"

--- a/.github/workflows/oracle.yml
+++ b/.github/workflows/oracle.yml
@@ -51,8 +51,8 @@ jobs:
         with:
           path: local
           key: perl-${{ steps.perl.outputs.perl-hash }}
-      - run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends --cpanfile dist/cpanfile
-      - run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends DBD::Oracle
+      - run: cpm install --top-level-phase configure,build,test,runtime --verbose --show-build-log-on-failure --no-test --top-level-relationship requires,recommends --cpanfile dist/cpanfile
+      - run: cpm install --top-level-phase configure,build,test,runtime --verbose --show-build-log-on-failure --no-test --top-level-relationship requires,recommends DBD::Oracle
       - name: prove
         env:
           PERL5LIB: "${{ github.workspace }}/local/lib/perl5"

--- a/.github/workflows/os.yml
+++ b/.github/workflows/os.yml
@@ -33,11 +33,11 @@ jobs:
         with:
           path: local
           key: perl-${{ steps.perl.outputs.perl-hash }}
-      - run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends ExtUtils::MakeMaker List::MoreUtils::XS
+      - run: cpm install --top-level-phase configure,build,test,runtime --verbose --show-build-log-on-failure --no-test --top-level-relationship requires,recommends ExtUtils::MakeMaker List::MoreUtils::XS
       - if: runner.os == 'Windows'
-        run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends Encode Win32::Console::ANSI Win32API::Net Win32::Locale Win32::ShellQuote DateTime::TimeZone::Local::Win32
-      - run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends --cpanfile dist/cpanfile
-      - run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends Test::Spelling Test::Pod Test::Pod::Coverage
+        run: cpm install --top-level-phase configure,build,test,runtime --verbose --show-build-log-on-failure --no-test --top-level-relationship requires,recommends Encode Win32::Console::ANSI Win32API::Net Win32::Locale Win32::ShellQuote DateTime::TimeZone::Local::Win32
+      - run: cpm install --top-level-phase configure,build,test,runtime --verbose --show-build-log-on-failure --no-test --top-level-relationship requires,recommends --cpanfile dist/cpanfile
+      - run: cpm install --top-level-phase configure,build,test,runtime --verbose --show-build-log-on-failure --no-test --top-level-relationship requires,recommends Test::Spelling Test::Pod Test::Pod::Coverage
       - name: prove
         env: { PERL5LIB: "${{ github.workspace }}/local/lib/perl5" }
         run: prove -lrj4

--- a/.github/workflows/perl.yml
+++ b/.github/workflows/perl.yml
@@ -10,18 +10,27 @@ on:
 jobs:
   Perl:
     strategy:
+      fail-fast: false
       matrix:
         os: [[🐧, ubuntu], [🍎, macos], [🪟, windows]]
         perl: [ '5.42', '5.40', '5.38', '5.36', '5.34', '5.32', '5.30', '5.28', '5.26', '5.24', '5.22', '5.20', '5.18', '5.16', '5.14', '5.12' ]
         exclude:
-          - { os: [🪟, windows], perl: '5.12' } # https://github.com/shogo82148/actions-setup-perl/issues/876
-          - { os: [🪟, windows], perl: '5.14' } # https://github.com/shogo82148/actions-setup-perl/issues/881
-          - { os: [🪟, windows], perl: '5.22' } # https://github.com/shogo82148/actions-setup-perl/issues/2310
-          - { os: [🪟, windows], perl: '5.24' } # https://github.com/shogo82148/actions-setup-perl/issues/2310
+          - { os: [🪟, windows], perl: '5.12' } # cpm too much a PITA && https://github.com/shogo82148/actions-setup-perl/issues/876
+          - { os: [🪟, windows], perl: '5.14' } # cpm too much a PITA && https://github.com/shogo82148/actions-setup-perl/issues/881
+          - { os: [🪟, windows], perl: '5.16' } # cpm too much a PITA
+          - { os: [🪟, windows], perl: '5.18' } # cpm too much a PITA
+          - { os: [🪟, windows], perl: '5.20' } # cpm too much a PITA
+          - { os: [🪟, windows], perl: '5.22' } # cpm too much a PITA && https://github.com/shogo82148/actions-setup-perl/issues/2310
+          - { os: [🪟, windows], perl: '5.24' } # cpm too much a PITA && https://github.com/shogo82148/actions-setup-perl/issues/2310
           - { os: [🪟, windows], perl: '5.40' } # https://github.com/shogo82148/actions-setup-perl/issues/2310
           - { os: [🪟, windows], perl: '5.42' } # https://github.com/shogo82148/actions-setup-perl/issues/2310
+          - { os: [🪟, windows], perl: '5.26' } # https://github.com/shogo82148/actions-setup-perl/issues/2669
+          - { os: [🪟, windows], perl: '5.28' } # https://github.com/shogo82148/actions-setup-perl/issues/2669
     name: 🧅 Perl ${{ matrix.perl }} on ${{ matrix.os[0] }} ${{ matrix.os[1] }}
     runs-on: ${{ matrix.os[1] }}-latest
+    env:
+      # Set args for cpm depending on the Perl version.
+      CPM_ARGS: --verbose --show-build-log-on-failure --no-test ${{ matrix.perl < 5.24 && '--no-test --with-recommends' || '--top-level-phase configure,build,test,runtime --top-level-relationship requires,recommends' }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup Perl
@@ -37,10 +46,22 @@ jobs:
         with:
           path: local
           key: perl-${{ steps.perl.outputs.perl-hash }}
+      - if: matrix.perl < 5.24
+        # Newer SKAJI modules require 5.24; install older versions to compensate.
+        run: |
+          cpanm install --verbose --notest --no-man-pages Module::Build::Tiny Module::cpmfile@0.006 Darwin::InitObjC@0.001 Parallel::Pipes::App@0.201 Command::Runner@0.201 Proc::ForkSafe@0.001 CPAN::02Packages::Search@0.100 App::cpm@0.998003
+          perl -E 'use Config; say $Config{sitebin}' >> "${{ github.path }}"
+      - if: matrix.perl < 5.18
+        # cpanm fails to install the cpm script above, but a manual install works.
+        working-directory: ${{ runner.temp }}
+        run: |
+          curl -O https://cpan.metacpan.org/authors/id/S/SK/SKAJI/App-cpm-0.998003.tar.gz
+          tar zxf App-cpm-0.998003.tar.gz && cd App-cpm-0.998003
+          perl Build.PL && ./Build && ./Build install
       - if: runner.os == 'Windows'
-        run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends Encode Win32::Console::ANSI Win32API::Net Win32::Locale Win32::ShellQuote DateTime::TimeZone::Local::Win32
-      - run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends --cpanfile dist/cpanfile
-      - run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends Test::Spelling Test::Pod Test::Pod::Coverage
+        run: cpm install ${{ env.CPM_ARGS }} Encode Win32::Console::ANSI Win32API::Net Win32::Locale Win32::ShellQuote DateTime::TimeZone::Local::Win32
+      - run: cpm install ${{ env.CPM_ARGS }} --cpanfile dist/cpanfile
+      - run: cpm install ${{ env.CPM_ARGS }} Test::Spelling Test::Pod Test::Pod::Coverage
       - name: prove
         env: { PERL5LIB: "${{ github.workspace }}/local/lib/perl5" }
         run: prove -lrj4

--- a/.github/workflows/pg.yml
+++ b/.github/workflows/pg.yml
@@ -24,13 +24,13 @@ jobs:
         with:
           path: local
           key: perl-${{ steps.perl.outputs.perl-hash }}
-      - run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends --cpanfile dist/cpanfile
+      - run: cpm install --top-level-phase configure,build,test,runtime --verbose --show-build-log-on-failure --no-test --top-level-relationship requires,recommends --cpanfile dist/cpanfile
         # DBD::Pg always build against the Debian packaged client, alas, so go
         # ahead and let it be cached. If can figure out how to install the
         # version-specific client (https://github.com/bucardo/dbdpg/issues/84),
-        # use cpm install --global to install DBD::Pg for a version-specific
+        # use cpm install --top-level-phase configure,build,test,runtime --global to install DBD::Pg for a version-specific
         # build each time.
-      - run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends DBD::Pg
+      - run: cpm install --top-level-phase configure,build,test,runtime --verbose --show-build-log-on-failure --no-test --top-level-relationship requires,recommends DBD::Pg
       - name: Install Postgres
         env: { PERL5LIB: "${{ github.workspace }}/local/lib/perl5" }
         run: .github/ubuntu/pg.sh ${{ matrix.pg }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,12 +27,12 @@ jobs:
         sudo apt-get update -qq
         sudo env DEBIAN_FRONTEND=noninteractive apt-get install -qq libicu-dev gettext aspell-en software-properties-common
     - name: Install Dist::Zilla
-      run: cpm install --verbose --show-build-log-on-failure --no-test Dist::Zilla
+      run: cpm install --top-level-phase configure,build,test,runtime --verbose --show-build-log-on-failure --no-test Dist::Zilla
     - name: Install Build Dependencies
       env: { PERL5LIB: "${{ github.workspace }}/local/lib/perl5" }
-      run: local/bin/dzil authordeps | xargs cpm install --verbose --show-build-log-on-failure --no-test
+      run: local/bin/dzil authordeps | xargs cpm install --top-level-phase configure,build,test,runtime --verbose --show-build-log-on-failure --no-test
     - name: Install Dependencies
-      run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends --cpanfile dist/cpanfile
+      run: cpm install --top-level-phase configure,build,test,runtime --verbose --show-build-log-on-failure --no-test --top-level-relationship requires,recommends --cpanfile dist/cpanfile
     - name: Prepare PAUSE
       env:
         CPAN_USERNAME: ${{ secrets.CPAN_USERNAME }}

--- a/.github/workflows/snowflake.yml
+++ b/.github/workflows/snowflake.yml
@@ -26,8 +26,8 @@ jobs:
         with:
           path: local
           key: perl-${{ steps.perl.outputs.perl-hash }}
-      - run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends --cpanfile dist/cpanfile
-      - run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends DBD::ODBC
+      - run: cpm install --top-level-phase configure,build,test,runtime --verbose --show-build-log-on-failure --no-test --top-level-relationship requires,recommends --cpanfile dist/cpanfile
+      - run: cpm install --top-level-phase configure,build,test,runtime --verbose --show-build-log-on-failure --no-test --top-level-relationship requires,recommends DBD::ODBC
       - name: prove
         env:
           PERL5LIB: "${{ github.workspace }}/local/lib/perl5"

--- a/.github/workflows/sqlite.yml
+++ b/.github/workflows/sqlite.yml
@@ -25,8 +25,8 @@ jobs:
         with:
           path: local
           key: perl-${{ steps.perl.outputs.perl-hash }}
-      - run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends --cpanfile dist/cpanfile
-      - run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends DBI
+      - run: cpm install --top-level-phase configure,build,test,runtime --verbose --show-build-log-on-failure --no-test --top-level-relationship requires,recommends --cpanfile dist/cpanfile
+      - run: cpm install --top-level-phase configure,build,test,runtime --verbose --show-build-log-on-failure --no-test --top-level-relationship requires,recommends DBI
       - name: Install SQLite
         env: { PERL5LIB: "${{ github.workspace }}/local/lib/perl5" }
         run: .github/ubuntu/sqlite.sh ${{ matrix.sqlite }}

--- a/.github/workflows/vertica.yml
+++ b/.github/workflows/vertica.yml
@@ -41,8 +41,8 @@ jobs:
         with:
           path: local
           key: perl-${{ steps.perl.outputs.perl-hash }}
-      - run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends --cpanfile dist/cpanfile
-      - run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends DBD::ODBC
+      - run: cpm install --top-level-phase configure,build,test,runtime --verbose --show-build-log-on-failure --no-test --top-level-relationship requires,recommends --cpanfile dist/cpanfile
+      - run: cpm install --top-level-phase configure,build,test,runtime --verbose --show-build-log-on-failure --no-test --top-level-relationship requires,recommends DBD::ODBC
       - name: prove
         env:
           PERL5LIB: "${{ github.workspace }}/local/lib/perl5"

--- a/.github/workflows/yugabyte.yml
+++ b/.github/workflows/yugabyte.yml
@@ -50,8 +50,8 @@ jobs:
         with:
           path: local
           key: perl-${{ steps.perl.outputs.perl-hash }}
-      - run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends --cpanfile dist/cpanfile
-      - run: cpm install --verbose --show-build-log-on-failure --no-test --with-recommends DBD::Pg
+      - run: cpm install --top-level-phase configure,build,test,runtime --verbose --show-build-log-on-failure --no-test --top-level-relationship requires,recommends --cpanfile dist/cpanfile
+      - run: cpm install --top-level-phase configure,build,test,runtime --verbose --show-build-log-on-failure --no-test --top-level-relationship requires,recommends DBD::Pg
       - name: prove
         env:
           PERL5LIB: "${{ github.workspace }}/local/lib/perl5"

--- a/Changes
+++ b/Changes
@@ -2,6 +2,12 @@ Revision history for Perl extension App::Sqitch
 
 1.6.2  Not Yet Released
 
+     - Fixed the `"ident" without a package or object reference` test failure
+       due to a recent change to Test::MockModule or some module it depends on
+       clearing the error variable `$@`. Thanks Slaven Rezić for the report
+       (#921)!
+     - Added CockroachDB 26.2 testing and fixed a test failure.
+
 1.6.1  2026-01-06T18:07:23Z
      - Fixed some ancient typos in sqitchtutorial-sqlite, with thanks to @ovid
        for the report!

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ SOFTWARE.
   [Vertica]:   https://github.com/sqitchers/sqitch/actions/workflows/vertica.yml/badge.svg
   [🔺]:        https://github.com/sqitchers/sqitch/actions/workflows/vertica.yml "Tested with Vertica 7.2–12.0"
   [Cockroach]: https://github.com/sqitchers/sqitch/actions/workflows/cockroach.yml/badge.svg
-  [🪳]:        https://github.com/sqitchers/sqitch/actions/workflows/cockroach.yml "Tested with CockroachDB v21–24"
+  [🪳]:        https://github.com/sqitchers/sqitch/actions/workflows/cockroach.yml "Tested with CockroachDB v23–26"
   [ClickHouse]: https://github.com/sqitchers/sqitch/actions/workflows/clickhouse.yml/badge.svg
   [🏠]:          https://github.com/sqitchers/sqitch/actions/workflows/clickhouse.yml "Tested with ClickHouse v25.8–25.9"
 

--- a/t/cockroach.t
+++ b/t/cockroach.t
@@ -135,8 +135,14 @@ END {
         $h->disconnect if $h->{Type} eq 'db' && $h->{Active} && $h ne $dbh;
     });
 
-    # Drop the database or schema.
-    $dbh->do("DROP DATABASE $db") if $dbh->{Active}
+    # Drop the database or schema. v26 raises a notice about waiting for jobs
+    # to finish as an error, so suppress notices.
+    if ($dbh->{Active}) {
+        $dbh->do($_) for (
+            "SET client_min_messages = warning",
+            "DROP DATABASE IF EXISTS $db",
+        );
+    }
 }
 
 my $err = try {

--- a/t/engine.t
+++ b/t/engine.t
@@ -2497,13 +2497,13 @@ is_deeply +MockOutput->get_info, [], 'Should have no info output';
 $mock_engine->mock(run_verify => sub { die 'OHNO' });
 throws_ok { $engine->verify_change($change) } 'App::Sqitch::X',
     'Should throw error on verify failure';
-$mock_engine->unmock('run_verify');
 is $@->ident, 'verify', 'Verify error ident should be "verify"';
 like $@->previous_exception, qr/OHNO/, 'Previous exception should be captured';
 is $@->message, __x(
     'Verify script "{script}" failed.',
     script => $change->verify_file
 ), 'Verify error message should be correct';
+$mock_engine->unmock('run_verify');
 is_deeply $engine->seen, [], 'Should have seen not method calls';
 is_deeply +MockOutput->get_info, [], 'Should have no info output';
 


### PR DESCRIPTION
Don't unmock till done testing `$@`; fix tests

It seems like a recent change caused `$mock_engine->unmock('run_verify')` to reset `$@`, causing the tests that followed it to fail. Move the unmock call to after the `$@`-using tests.` Thanks @eserte for the report (resolves #921).

Also update the test workflows for changes to recent release of `cpm`. Change them to use the new argument `--top-level-phase configure,build,test,runtime`; otherwise `cpm` defaults to installing development modules, too (see skaji/cpm#310).

Also work around `cpm` and related modules dropping support for Perl versions prior to 5.24 by installing the last versions to support Perl 5.22 and earlier in the "🧅 Perl" workflow (see shogo82148/actions-setup-perl#2662). This requires using a variable for the `cpm` arguments to support both versions, and requires a further workaround on Perl 5.16 and earlier. And cease testing Perls before 5.24 on Windows, where things just don't work well at all.

Update the CockroachDB versions to include 26.2 and drop 21 and 22, as their DockerHub images have been deleted. Work around a test failure on 26.2 returning a `NOTICE` as an error for some reason, too.